### PR TITLE
Add --top-files-length option to customize top files display

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This file contains the contents of my repository combined into a single file. I'
 
 - `-v, --version`: Show tool version
 - `-o, --output <file>`: Specify the output file name
+- `--top-files-len <number>`: Number of top files to display in the summary
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `-c, --config <path>`: Path to a custom config file
 - `--verbose`: Enable verbose logging
@@ -98,6 +99,7 @@ Create a `repopack.config.json` file in your project root for custom configurati
 |`output.filePath`| The name of the output file | `"repopack-output.txt"` |
 |`output.headerText`| Custom text to include in the file header |`null`|
 |`output.removeComments`| Whether to remove comments from supported file types. Suppurts python  | `false` |
+|`output.topFilesLength`| Number of top files to display in the summary |`5`|
 |`ignore.useDefaultPatterns`| Whether to use default ignore patterns |`true`|
 |`ignore.customPatterns`| Additional patterns to ignore |`[]`|
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repopack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repopack",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "cli-spinners": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repopack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A tool to pack repository contents to single file for AI consumption",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/repopack.config.json
+++ b/repopack.config.json
@@ -2,7 +2,8 @@
   "output": {
     "filePath": "repopack-output.txt",
     "headerText": "This repository contains the source code for the Repopack tool.\nRepopack is designed to pack repository contents into a single file,\nmaking it easier for AI systems to analyze and process the codebase.\n\nKey Features:\n- Configurable ignore patterns\n- Custom header text support\n- Efficient file processing and packing\n\nPlease refer to the README.md file for more detailed information on usage and configuration.\n",
-    "removeComments": false
+    "removeComments": false,
+    "topFilesLength": 5
   },
   "ignore": {
     "useDefaultPatterns": true,

--- a/src/cli/cliOutput.ts
+++ b/src/cli/cliOutput.ts
@@ -1,0 +1,28 @@
+import pc from 'picocolors';
+
+export function printSummary(totalFiles: number, totalCharacters: number, outputPath: string) {
+  console.log(pc.white('📊 Pack Summary:'));
+  console.log(pc.dim('────────────────'));
+  console.log(`${pc.white('Total Files:')} ${pc.white(totalFiles.toString())}`);
+  console.log(`${pc.white('Total Chars:')} ${pc.white(totalCharacters.toString())}`);
+  console.log(`${pc.white('     Output:')} ${pc.white(outputPath)}`);
+}
+
+export function printTopFiles(fileCharCounts: Record<string, number>, topFilesLength: number) {
+  console.log(pc.white(`📈 Top ${topFilesLength} Files by Character Count:`));
+  console.log(pc.dim('──────────────────────────────────'));
+
+  const topFiles = Object.entries(fileCharCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topFilesLength);
+
+  topFiles.forEach(([filePath, count], index) => {
+    const indexString = `${index + 1}.`.padEnd(3, ' ');
+    console.log(`${pc.white(`${indexString}`)} ${pc.white(filePath)} ${pc.dim(`(${count} chars)`)}`);
+  });
+}
+
+export function printCompletion() {
+  console.log(pc.green('🎉 All Done!'));
+  console.log(pc.white('Your repository has been successfully packed.'));
+}

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -4,6 +4,7 @@ export const defaultConfig: RepopackConfigDefault = {
   output: {
     filePath: 'repopack-output.txt',
     removeComments: false,
+    topFilesLength: 5,
   },
   ignore: {
     useDefaultPatterns: true,

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -20,6 +20,7 @@ export interface Dependencies {
 export interface PackResult {
   totalFiles: number;
   totalCharacters: number;
+  fileCharCounts: Record<string, number>;
 }
 
 export async function pack(
@@ -44,9 +45,15 @@ export async function pack(
 
   await deps.generateOutput(rootDir, config, packedFiles);
 
+  const fileCharCounts: Record<string, number> = {};
+  packedFiles.forEach((file) => {
+    fileCharCounts[file.path] = file.content.length;
+  });
+
   return {
     totalFiles,
     totalCharacters,
+    fileCharCounts,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ interface RepopackConfigBase {
     filePath?: string;
     headerText?: string;
     removeComments?: boolean;
+    topFilesLength?: number;
   };
   ignore?: {
     useDefaultPatterns?: boolean;
@@ -15,6 +16,7 @@ export type RepopackConfigDefault = RepopackConfigBase & {
     filePath: string;
     headerText?: string;
     removeComments?: boolean;
+    topFilesLength: number;
   };
   ignore: {
     useDefaultPatterns: boolean;
@@ -27,6 +29,7 @@ export type RepopackConfigFile = RepopackConfigBase & {
     filePath?: string;
     headerText?: string;
     removeComments?: boolean;
+    topFilesLength?: number;
   };
   ignore?: {
     useDefaultPatterns?: boolean;
@@ -39,6 +42,7 @@ export type RepopackConfigCli = RepopackConfigBase & {
     filePath?: string;
     headerText?: string;
     removeComments?: boolean;
+    topFilesLength?: number;
   };
   ignore?: {
     useDefaultPatterns?: boolean;

--- a/tests/core/outputGenerator.test.ts
+++ b/tests/core/outputGenerator.test.ts
@@ -13,7 +13,7 @@ describe('outputGenerator', () => {
 
   test('generateOutput should write correct content to file', async () => {
     const mockConfig: RepopackConfigMerged = {
-      output: { filePath: 'output.txt' },
+      output: { filePath: 'output.txt', topFilesLength: 2 },
       ignore: { useDefaultPatterns: true },
     };
     const mockPackedFiles = [
@@ -39,6 +39,7 @@ describe('outputGenerator', () => {
       output: {
         filePath: 'output.txt',
         headerText: 'Custom header text',
+        topFilesLength: 2,
       },
       ignore: { useDefaultPatterns: true },
     };

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -22,7 +22,7 @@ describe('packager', () => {
 
   test('pack should process files and generate output', async () => {
     const mockConfig: RepopackConfigMerged = {
-      output: { filePath: 'output.txt' },
+      output: { filePath: 'output.txt', topFilesLength: 2 },
       ignore: { useDefaultPatterns: true },
     };
 

--- a/tests/utils/fileHandler.test.ts
+++ b/tests/utils/fileHandler.test.ts
@@ -15,7 +15,7 @@ describe('fileHandler', () => {
     vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
     const mockConfig: RepopackConfigMerged = {
-      output: { filePath: 'output.txt' },
+      output: { filePath: 'output.txt', topFilesLength: 2 },
       ignore: { useDefaultPatterns: true },
     };
     const result = await processFile('/path/to/file.txt', mockConfig);


### PR DESCRIPTION
This PR introduces a new feature that allows users to customize the number of top files displayed in the output summary.

Changes:
1. Added a new CLI option `--top-files-length` to specify the number of top files to display.
2. Updated the configuration to include `topFilesLength` in the `output` section.
3. Modified the `printTopFiles` function to use the new `topFilesLength` setting.
4. Updated README.md to document the new option.

This enhancement provides users with more flexibility in viewing the most significant files in their repository based on character count.