### PR TITLE
Clarify binary file handling in README and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ REPOPACK OUTPUT FILE
 (Metadata and usage AI instructions)
 
 ================================================================
+Repository Structure
+================================================================
+src/
+  cli/
+    cliOutput.ts
+    index.ts
+  config/
+    configLoader.ts
+    configValidator.ts
+    defaultConfig.ts
+    index.ts
+
+(...remaining directories)
+
+================================================================
 Repository Files
 ================================================================
 
@@ -185,6 +200,8 @@ Priority Order (from highest to lowest):
 4. Default patterns (if `ignore.useDefaultPatterns` is true)
 
 This approach allows for flexible file exclusion configuration based on your project's needs. It helps optimize the size of the generated pack file by ensuring the exclusion of security-sensitive files and large binary files, while preventing the leakage of confidential information.
+
+Note: Binary files are not included in the packed output by default, but their paths are listed in the "Repository Structure" section of the output file. This provides a complete overview of the repository structure while keeping the packed file efficient and text-based.
 
 ### Comment Removal
 

--- a/src/core/outputGenerator.ts
+++ b/src/core/outputGenerator.ts
@@ -2,7 +2,7 @@ import { RepopackConfigMerged } from '../types/index.js';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import { generateTreeString } from '../utils/treeGenerator.js';
-import { PackedFile } from './packager.js';
+import { SanitizedFile } from '../utils/fileHandler.js';
 
 const SEPARATOR = '='.repeat(16);
 const LONG_SEPARATOR = '='.repeat(64);
@@ -10,17 +10,17 @@ const LONG_SEPARATOR = '='.repeat(64);
 export async function generateOutput(
   rootDir: string,
   config: RepopackConfigMerged,
-  packedFiles: PackedFile[],
+  sanitizedFiles: SanitizedFile[],
   fsModule = fs,
 ): Promise<void> {
   const output: string[] = [];
 
   // Generate and add the header
-  const header = generateFileHeader(config, packedFiles);
+  const header = generateFileHeader(config, sanitizedFiles);
   output.push(header);
 
-  // Add packed files
-  for (const file of packedFiles) {
+  // Add sanitized files
+  for (const file of sanitizedFiles) {
     output.push(SEPARATOR);
     output.push(`File: ${file.path}`);
     output.push(SEPARATOR);
@@ -40,8 +40,8 @@ export async function generateOutput(
   await fsModule.writeFile(outputPath, output.join('\n'));
 }
 
-export function generateFileHeader(config: RepopackConfigMerged, packedFiles: PackedFile[]): string {
-  const fileTree = generateTreeString(packedFiles.map((file) => file.path));
+export function generateFileHeader(config: RepopackConfigMerged, sanitizedFiles: SanitizedFile[]): string {
+  const fileTree = generateTreeString(sanitizedFiles.map((file) => file.path));
 
   const defaultHeader = `${LONG_SEPARATOR}
 Repopack Output File

--- a/src/core/outputGenerator.ts
+++ b/src/core/outputGenerator.ts
@@ -11,12 +11,13 @@ export async function generateOutput(
   rootDir: string,
   config: RepopackConfigMerged,
   sanitizedFiles: SanitizedFile[],
+  allFilePaths: string[],
   fsModule = fs,
 ): Promise<void> {
   const output: string[] = [];
 
   // Generate and add the header
-  const header = generateFileHeader(config, sanitizedFiles);
+  const header = generateFileHeader(config, allFilePaths);
   output.push(header);
 
   // Add sanitized files
@@ -40,8 +41,8 @@ export async function generateOutput(
   await fsModule.writeFile(outputPath, output.join('\n'));
 }
 
-export function generateFileHeader(config: RepopackConfigMerged, sanitizedFiles: SanitizedFile[]): string {
-  const fileTree = generateTreeString(sanitizedFiles.map((file) => file.path));
+export function generateFileHeader(config: RepopackConfigMerged, allFilePaths: string[]): string {
+  const fileTree = generateTreeString(allFilePaths);
 
   const defaultHeader = `${LONG_SEPARATOR}
 Repopack Output File
@@ -60,26 +61,28 @@ File Format:
 The content is organized as follows:
 1. This header section
 2. Multiple file entries, each consisting of:
-   a. A separator line (${SEPARATOR})
-   b. The file path (File: path/to/file)
-   c. Another separator line
-   d. The full contents of the file
-   e. A blank line
+  a. A separator line (${SEPARATOR})
+  b. The file path (File: path/to/file)
+  c. Another separator line
+  d. The full contents of the file
+  e. A blank line
 
 Usage Guidelines:
 -----------------
 1. This file should be treated as read-only. Any changes should be made to the
-   original repository files, not this packed version.
+  original repository files, not this packed version.
 2. When processing this file, use the separators and "File:" markers to
-   distinguish between different files in the repository.
+  distinguish between different files in the repository.
 3. Be aware that this file may contain sensitive information. Handle it with
-   the same level of security as you would the original repository.
+  the same level of security as you would the original repository.
 
 Notes:
 ------
 - Some files may have been excluded based on .gitignore rules and Repopack's
   configuration.
-- Binary files are not included in this packed representation.
+- Binary files are not included in this packed representation. Please refer to
+  the Repository Structure section for a complete list of file paths, including
+  binary files.
 ${config.output.removeComments ? '- Code comments have been removed.\n' : ''}
 ${config.output.showLineNumbers ? '- Line numbers have been added to the beginning of each line.\n' : ''}
 

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -48,7 +48,7 @@ export async function pack(
 
   // Sanitize files and generate output
   const sanitizedFiles = await deps.sanitizeFiles(filePaths, rootDir, config);
-  await deps.generateOutput(rootDir, config, sanitizedFiles);
+  await deps.generateOutput(rootDir, config, sanitizedFiles, filePaths);
 
   // Metrics
   const totalFiles = sanitizedFiles.length;

--- a/src/utils/fileHandler.ts
+++ b/src/utils/fileHandler.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import path from 'node:path';
 import { isBinary } from 'istextorbinary';
 import jschardet from 'jschardet';
 import iconv from 'iconv-lite';
@@ -6,7 +7,30 @@ import { RepopackConfigMerged } from '../types/index.js';
 import { getFileManipulator } from './fileManipulator.js';
 import { logger } from './logger.js';
 
-export async function processFile(
+export interface SanitizedFile {
+  path: string;
+  content: string;
+}
+
+export async function sanitizeFiles(
+  filePaths: string[],
+  rootDir: string,
+  config: RepopackConfigMerged,
+): Promise<SanitizedFile[]> {
+  const sanitizedFiles: SanitizedFile[] = [];
+
+  for (const filePath of filePaths) {
+    const fullPath = path.join(rootDir, filePath);
+    const content = await sanitizeFile(fullPath, config);
+    if (content) {
+      sanitizedFiles.push({ path: filePath, content });
+    }
+  }
+
+  return sanitizedFiles;
+}
+
+export async function sanitizeFile(
   filePath: string,
   config: RepopackConfigMerged,
   fsModule = fs,

--- a/tests/core/outputGenerator.test.ts
+++ b/tests/core/outputGenerator.test.ts
@@ -21,12 +21,12 @@ describe('outputGenerator', () => {
         removeEmptyLines: false,
       },
     });
-    const mockPackedFiles = [
+    const mockSanitizedFiles = [
       { path: 'file1.txt', content: 'content1' },
       { path: 'dir/file2.txt', content: 'content2' },
     ];
 
-    await generateOutput('root', mockConfig, mockPackedFiles);
+    await generateOutput('root', mockConfig, mockSanitizedFiles);
 
     expect(fs.writeFile).toHaveBeenCalledTimes(1);
     expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(path.resolve('root', 'output.txt'));

--- a/tests/core/outputGenerator.test.ts
+++ b/tests/core/outputGenerator.test.ts
@@ -26,7 +26,7 @@ describe('outputGenerator', () => {
       { path: 'dir/file2.txt', content: 'content2' },
     ];
 
-    await generateOutput('root', mockConfig, mockSanitizedFiles);
+    await generateOutput('root', mockConfig, mockSanitizedFiles, []);
 
     expect(fs.writeFile).toHaveBeenCalledTimes(1);
     expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(path.resolve('root', 'output.txt'));

--- a/tests/core/packager.test.ts
+++ b/tests/core/packager.test.ts
@@ -12,13 +12,14 @@ describe('packager', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    const file2Path = path.join('dir1', 'file2.txt');
     mockDeps = {
       getAllIgnorePatterns: vi.fn().mockResolvedValue([]),
       createIgnoreFilter: vi.fn().mockReturnValue(() => true),
       generateOutput: vi.fn().mockResolvedValue(undefined),
       sanitizeFiles: vi.fn().mockResolvedValue([
         { path: 'file1.txt', content: 'processed content 1' },
-        { path: 'dir1/file2.txt', content: 'processed content 2' },
+        { path: file2Path, content: 'processed content 2' },
       ]),
     };
   });
@@ -41,22 +42,24 @@ describe('packager', () => {
 
     expect(mockDeps.getAllIgnorePatterns).toHaveBeenCalledWith('root', mockConfig);
     expect(mockDeps.createIgnoreFilter).toHaveBeenCalled();
-    expect(mockDeps.sanitizeFiles).toHaveBeenCalledWith(
-      ['file1.txt', path.join('dir1', 'file2.txt')],
+    const file2Path = path.join('dir1', 'file2.txt');
+    expect(mockDeps.sanitizeFiles).toHaveBeenCalledWith(['file1.txt', file2Path], 'root', mockConfig);
+    expect(mockDeps.generateOutput).toHaveBeenCalledWith(
       'root',
       mockConfig,
+      [
+        { path: 'file1.txt', content: 'processed content 1' },
+        { path: file2Path, content: 'processed content 2' },
+      ],
+      ['file1.txt', file2Path],
     );
-    expect(mockDeps.generateOutput).toHaveBeenCalledWith('root', mockConfig, [
-      { path: 'file1.txt', content: 'processed content 1' },
-      { path: 'dir1/file2.txt', content: 'processed content 2' },
-    ]);
 
     // Check the result of pack function
     expect(result.totalFiles).toBe(2);
     expect(result.totalCharacters).toBe(38); // 'processed content 1' + 'processed content 2'
     expect(result.fileCharCounts).toEqual({
       'file1.txt': 19,
-      'dir1/file2.txt': 19,
+      [file2Path]: 19,
     });
   });
 });


### PR DESCRIPTION
## Changes
- Added a note about binary file handling in the "Ignore Patterns" section of README.md
- Updated the code to include binary file paths in the "Repository Structure" section of the output

## Reason for changes
- To clearly communicate how binary files are processed to users
- To provide a complete overview of the repository structure, including binary files
- To enhance transparency about the content and structure of the packed repository
