### PR TITLE
feat(cli): Add CLI option for output style

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Feel free to modify these prompts based on your specific needs and the capabilit
 - `-o, --output <file>`: Specify the output file name
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `-c, --config <path>`: Path to a custom config file
+- `--style <style>`: Specify the output style (`plain` or `xml`)
 - `--top-files-len <number>`: Number of top files to display in the summary
 - `--output-show-line-numbers`: Show line numbers in the output
 - `--verbose`: Enable verbose logging
@@ -145,6 +146,7 @@ Examples:
 repopack -o custom-output.txt
 repopack -i "*.log,tmp" -v
 repopack -c ./custom-config.json
+repopack --style xml
 npx repopack src
 ```
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,7 @@
 import { program, OptionValues } from 'commander';
 import path from 'node:path';
 import { pack } from '../core/packager.js';
-import { RepopackConfigCli, RepopackConfigFile, RepopackConfigMerged } from '../types/index.js';
+import { RepopackConfigCli, RepopackConfigFile, RepopackConfigMerged, RepopackOutputStyle } from '../types/index.js';
 import { loadFileConfig, mergeConfigs } from '../config/configLoader.js';
 import { logger } from '../utils/logger.js';
 import { getVersion } from '../utils/packageJsonUtils.js';
@@ -19,6 +19,7 @@ interface CliOptions extends OptionValues {
   verbose?: boolean;
   topFilesLen?: number;
   outputShowLineNumbers?: boolean;
+  style?: RepopackOutputStyle;
 }
 
 async function executeAction(directory: string, rootDir: string, options: CliOptions) {
@@ -48,6 +49,9 @@ async function executeAction(directory: string, rootDir: string, options: CliOpt
   }
   if (options.outputShowLineNumbers !== undefined) {
     cliConfig.output = { ...cliConfig.output, showLineNumbers: options.outputShowLineNumbers };
+  }
+  if (options.style) {
+    cliConfig.output = { ...cliConfig.output, style: options.style.toLowerCase() as RepopackOutputStyle };
   }
   logger.trace('CLI config:', cliConfig);
 
@@ -106,6 +110,7 @@ export async function run() {
       .option('-c, --config <path>', 'path to a custom config file')
       .option('--top-files-len <number>', 'specify the number of top files to display', parseInt)
       .option('--output-show-line-numbers', 'add line numbers to each line in the output')
+      .option('--style <type>', 'specify the output style (plain or xml)')
       .option('--verbose', 'enable verbose logging for detailed output')
       .action((directory = '.', options: CliOptions) => executeAction(directory, process.cwd(), options));
 

--- a/src/config/configValidator.ts
+++ b/src/config/configValidator.ts
@@ -21,16 +21,24 @@ export function validateConfig(config: unknown): asserts config is RepopackConfi
       throw new RepopackConfigValidationError('output must be an object');
     }
 
-    const { filePath, headerText } = output;
+    const { filePath, headerText, style } = output;
     if (filePath !== undefined && typeof filePath !== 'string') {
       throw new RepopackConfigValidationError('output.filePath must be a string');
     }
     if (headerText !== undefined && typeof headerText !== 'string') {
       throw new RepopackConfigValidationError('output.headerText must be a string');
     }
+    if (style !== undefined) {
+      if (typeof style !== 'string') {
+        throw new RepopackConfigValidationError('output.style must be a string');
+      }
+      if (style !== 'plain' && style !== 'xml') {
+        throw new RepopackConfigValidationError('output.style must be either "plain" or "xml"');
+      }
+    }
   }
 
-  // Validate ignore
+  // Validate ignore (existing code remains unchanged)
   if (ignore !== undefined) {
     if (typeof ignore !== 'object' || ignore === null) {
       throw new RepopackConfigValidationError('ignore must be an object');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-type RepopackOutputStyle = 'plain' | 'xml';
+export type RepopackOutputStyle = 'plain' | 'xml';
 
 interface RepopackConfigBase {
   output?: {

--- a/tests/config/configValidator.test.ts
+++ b/tests/config/configValidator.test.ts
@@ -28,4 +28,24 @@ describe('configValidator', () => {
     const invalidConfig = { ignore: { customPatterns: 'not an array' } };
     expect(() => validateConfig(invalidConfig)).toThrow(RepopackConfigValidationError);
   });
+
+  test('should pass for a valid config with output style', () => {
+    const validConfig = {
+      output: { filePath: 'test.txt', style: 'xml' },
+      ignore: { useDefaultPatterns: true },
+    };
+    expect(() => validateConfig(validConfig)).not.toThrow();
+  });
+
+  test('should throw for invalid output.style type', () => {
+    const invalidConfig = { output: { style: 123 } };
+    expect(() => validateConfig(invalidConfig)).toThrow(RepopackConfigValidationError);
+    expect(() => validateConfig(invalidConfig)).toThrow('output.style must be a string');
+  });
+
+  test('should throw for invalid output.style value', () => {
+    const invalidConfig = { output: { style: 'invalid' } };
+    expect(() => validateConfig(invalidConfig)).toThrow(RepopackConfigValidationError);
+    expect(() => validateConfig(invalidConfig)).toThrow('output.style must be either "plain" or "xml"');
+  });
 });


### PR DESCRIPTION
This PR adds a new CLI option `--style` to allow users to specify the output style (plain or xml) directly from the command line. It also includes validation to ensure only valid styles are accepted in both the CLI and config file.

## Changes
- Added `--style` option to CLI
- Updated config validation to check for valid style values
