### PR TITLE
Exclude output file from being included in the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage/
 
 # Repopack output
 repopack-output.txt
+repopack-output.xml
 
 # ESLint cache
 .eslintcache

--- a/repopack.config.json
+++ b/repopack.config.json
@@ -1,7 +1,7 @@
 {
   "output": {
-    "filePath": "repopack-output.txt",
-    "style": "plain",
+    "filePath": "repopack-output.xml",
+    "style": "xml",
     "headerText": "This repository contains the source code for the Repopack tool.\nRepopack is designed to pack repository contents into a single file,\nmaking it easier for AI systems to analyze and process the codebase.\n\nKey Features:\n- Configurable ignore patterns\n- Custom header text support\n- Efficient file processing and packing\n\nPlease refer to the README.md file for more detailed information on usage and configuration.\n",
     "removeComments": false,
     "removeEmptyLines": false,


### PR DESCRIPTION
## Problem
The file specified by `output.filePath` is currently included in the output itself, causing a recursive issue.

## Solution
Modify `getFilePaths` function in `src/core/packager.ts` to exclude the output file from processing.

