### PR TITLE
Remove XML escaping from output generator

### DIFF
--- a/src/core/outputGenerator.ts
+++ b/src/core/outputGenerator.ts
@@ -178,7 +178,7 @@ For more information about Repopack, visit: https://github.com/yamadashy/repopac
   if (config.output.headerText) {
     xml += `
 <user_provided_header>
-${escapeXml(config.output.headerText)}
+${config.output.headerText}
 </user_provided_header>
 `;
   }
@@ -187,7 +187,7 @@ ${escapeXml(config.output.headerText)}
 </summary>
 
 <repository_structure>
-${escapeXml(treeString)}
+${treeString}
 </repository_structure>
 
 <repository_files>
@@ -195,8 +195,8 @@ ${escapeXml(treeString)}
 
   for (const file of sanitizedFiles) {
     xml += `
-<file path="${escapeXml(file.path)}">
-${escapeXml(file.content)}
+<file path="${file.path}">
+${file.content}
 </file>
 `;
   }
@@ -206,22 +206,4 @@ ${escapeXml(file.content)}
 `;
 
   return xml.trim() + '\n';
-}
-
-function escapeXml(unsafe: string): string {
-  return unsafe.replace(/[<>&'"]/g, (c) => {
-    switch (c) {
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '&':
-        return '&amp;';
-      case "'":
-        return '&apos;';
-      case '"':
-        return '&quot;';
-    }
-    return c;
-  });
 }


### PR DESCRIPTION
This PR removes XML escaping from the output generator to improve readability and AI comprehension of the generated output.

## Changes:
- Removed XML escaping for file paths and contents in repository files

Note: This change assumes that the input data (file paths, contents, etc.) does not contain characters that would break XML syntax. If there's a possibility of such characters, we may need to implement a more robust solution, such as using CDATA sections for file contents.
