### PR TITLE
feat(cli): Add token counts for CLI outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Perfect for when you need to feed your codebase to Large Language Models (LLMs) 
 ## 🌟 Features
 
 - **AI-Optimized**: Formats your codebase in a way that's easy for AI to understand and process.
+- **Token Counting**: Provides token counts for each file and the entire repository, useful for LLM context limits.
 - **Simple to Use**: Just one command to pack your entire repository.
 - **Customizable**: Easily configure what to include or exclude.
 - **Git-Aware**: Automatically respects your .gitignore files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "jschardet": "^3.1.3",
         "log-update": "^6.1.0",
         "picocolors": "^1.0.1",
-        "strip-comments": "^2.0.1"
+        "strip-comments": "^2.0.1",
+        "tiktoken": "^1.0.15"
       },
       "bin": {
         "repopack": "bin/repopack.cjs"
@@ -5886,6 +5887,12 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
+    },
+    "node_modules/tiktoken": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.15.tgz",
+      "integrity": "sha512-sCsrq/vMWUSEW29CJLNmPvWxlVp7yh2tlkAjpJltIKqp5CKf98ZNpdeHRmAlPVFlGEbswDc6SmI8vz64W/qErw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "jschardet": "^3.1.3",
     "log-update": "^6.1.0",
     "picocolors": "^1.0.1",
-    "strip-comments": "^2.0.1"
+    "strip-comments": "^2.0.1",
+    "tiktoken": "^1.0.15"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/src/cli/cliOutput.ts
+++ b/src/cli/cliOutput.ts
@@ -6,6 +6,7 @@ export const printSummary = (
   rootDir: string,
   totalFiles: number,
   totalCharacters: number,
+  totalTokens: number,
   outputPath: string,
   suspiciousFilesResults: SecretLintCoreResult[],
 ) => {
@@ -20,10 +21,11 @@ export const printSummary = (
 
   console.log(pc.white('📊 Pack Summary:'));
   console.log(pc.dim('────────────────'));
-  console.log(`${pc.white('Total Files:')} ${pc.white(totalFiles.toString())}`);
-  console.log(`${pc.white('Total Chars:')} ${pc.white(totalCharacters.toString())}`);
-  console.log(`${pc.white('     Output:')} ${pc.white(relativeOutputPath)}`);
-  console.log(`${pc.white('   Security:')} ${pc.white(securityCheckMessage)}`);
+  console.log(`${pc.white('  Total Files:')} ${pc.white(totalFiles.toString())}`);
+  console.log(`${pc.white('  Total Chars:')} ${pc.white(totalCharacters.toString())}`);
+  console.log(`${pc.white(' Total Tokens:')} ${pc.white(totalTokens.toString())}`);
+  console.log(`${pc.white('       Output:')} ${pc.white(relativeOutputPath)}`);
+  console.log(`${pc.white('     Security:')} ${pc.white(securityCheckMessage)}`);
 };
 
 export const printSecurityCheck = (rootDir: string, suspiciousFilesResults: SecretLintCoreResult[]) => {
@@ -46,17 +48,24 @@ export const printSecurityCheck = (rootDir: string, suspiciousFilesResults: Secr
   }
 };
 
-export const printTopFiles = (fileCharCounts: Record<string, number>, topFilesLength: number) => {
-  console.log(pc.white(`📈 Top ${topFilesLength} Files by Character Count:`));
-  console.log(pc.dim('──────────────────────────────────'));
+export const printTopFiles = (
+  fileCharCounts: Record<string, number>,
+  fileTokenCounts: Record<string, number>,
+  topFilesLength: number,
+) => {
+  console.log(pc.white(`📈 Top ${topFilesLength} Files by Character Count and Token Count:`));
+  console.log(pc.dim('──────────────────────────────────────────────────────'));
 
   const topFiles = Object.entries(fileCharCounts)
     .sort((a, b) => b[1] - a[1])
     .slice(0, topFilesLength);
 
-  topFiles.forEach(([filePath, count], index) => {
+  topFiles.forEach(([filePath, charCount], index) => {
+    const tokenCount = fileTokenCounts[filePath];
     const indexString = `${index + 1}.`.padEnd(3, ' ');
-    console.log(`${pc.white(`${indexString}`)} ${pc.white(filePath)} ${pc.dim(`(${count} chars)`)}`);
+    console.log(
+      `${pc.white(`${indexString}`)} ${pc.white(filePath)} ${pc.dim(`(${charCount} chars, ${tokenCount} tokens)`)}`,
+    );
   });
 };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -83,7 +83,7 @@ const executeAction = async (directory: string, rootDir: string, options: CliOpt
     console.log('');
 
     if (config.output.topFilesLength > 0) {
-      printTopFiles(packResult.fileCharCounts, config.output.topFilesLength);
+      printTopFiles(packResult.fileCharCounts, packResult.fileTokenCounts, config.output.topFilesLength);
       console.log('');
     }
 
@@ -94,6 +94,7 @@ const executeAction = async (directory: string, rootDir: string, options: CliOpt
       rootDir,
       packResult.totalFiles,
       packResult.totalCharacters,
+      packResult.totalTokens,
       config.output.filePath,
       packResult.suspiciousFilesResults,
     );

--- a/tests/core/tokenCounter.test.ts
+++ b/tests/core/tokenCounter.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, describe, beforeAll, afterAll } from 'vitest';
+import { Tiktoken, get_encoding } from 'tiktoken';
+
+describe('tiktoken', () => {
+  let encoding: Tiktoken;
+
+  beforeAll(() => {
+    encoding = get_encoding('cl100k_base');
+  });
+
+  afterAll(() => {
+    encoding.free();
+  });
+
+  test('should correctly count tokens', () => {
+    const testCases = [
+      { input: 'Hello, world!', expectedTokens: 4 },
+      { input: 'This is a longer sentence with more tokens.', expectedTokens: 9 },
+      { input: 'Special characters like !@#$%^&*() should be handled correctly.', expectedTokens: 15 },
+      { input: 'Numbers 123 and symbols @#$ might affect tokenization.', expectedTokens: 12 },
+      { input: 'Multi-line\ntext\nshould\nwork\ntoo.', expectedTokens: 11 },
+    ];
+
+    testCases.forEach(({ input, expectedTokens }) => {
+      const tokenCount = encoding.encode(input).length;
+      expect(tokenCount).toBe(expectedTokens);
+    });
+  });
+
+  test('should handle empty input', () => {
+    const tokenCount = encoding.encode('').length;
+    expect(tokenCount).toBe(0);
+  });
+
+  test('should handle very long input', () => {
+    const longText = 'a'.repeat(1000);
+    const tokenCount = encoding.encode(longText).length;
+    expect(tokenCount).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
This PR adds support for token counting and CLI display using the `tiktoken` library. Provides token counts for individual files and the entire repository, which is useful for working within context limits.

Currently set to use `cl100k_base` as the encoder ([used for GPT-4, etc.](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)). Could add an option for customizing which encoder to use, but felt like the `cl100k_base` is "good enough" (getting >95% token count accuracy has very limited value IMO) and limits option scope.

Decided on the `tiktoken` library based on [high-level benchmarks](https://github.com/transitive-bullshit/compare-tokenizers), higher NPM weekly downloads, and fairly decent commit activity.

## Changes

- Added `tiktoken` as a dependency
- Updated `src/core/packager.ts` to include token counting
- Modified `src/cli/cliOutput.ts` to display token information in the summary and top files list
- Updated `src/cli/index.ts` to use the new token information
- Added a new test file `tests/core/tokenCounter.test.ts` for token counting functionality
- Updated `README.md`