### PR TITLE
Add `--init` command for interactive configuration setup

### DIFF
--- a/.repopackignore
+++ b/.repopackignore
@@ -1,4 +1,4 @@
 node_modules
 .yarn
 .eslinttcache
-tests/fixtures
+tests/integration-tests/fixtures

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ To exclude specific files or directories:
 repopack --ignore "**/*.log,tmp/"
 ```
 
+To initialize a new configuration file (`repopack.config.json`):
+
+```bash
+repopack --init
+```
+
 Once you have generated the packed file, you can use it with Generative AI tools like Claude, ChatGPT, and Gemini.
 
 ### Prompt Examples
@@ -235,7 +241,12 @@ Using `npx repopack` is generally more convenient as it always uses the latest v
 
 ## ⚙️ Configuration
 
-Create a `repopack.config.json` file in your project root for custom configurations. Here's an explanation of the configuration options:
+Create a `repopack.config.json` file in your project root for custom configurations.
+```bash
+repopack --init
+```
+
+Here's an explanation of the configuration options:
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^0.7.0",
         "@secretlint/core": "^8.2.4",
         "@secretlint/secretlint-rule-preset-recommend": "^8.2.4",
         "cli-spinners": "^2.9.2",
@@ -232,6 +233,42 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@clack/core": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.4.tgz",
+      "integrity": "sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.7.0.tgz",
+      "integrity": "sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==",
+      "bundleDependencies": [
+        "is-unicode-supported"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "^0.3.3",
+        "is-unicode-supported": "*",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -3844,7 +3881,8 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4329,6 +4367,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@clack/prompts": "^0.7.0",
     "@secretlint/core": "^8.2.4",
     "@secretlint/secretlint-rule-preset-recommend": "^8.2.4",
     "cli-spinners": "^2.9.2",
@@ -65,8 +66,8 @@
   "devDependencies": {
     "@eslint/js": "^9.8.0",
     "@types/eslint": "~8.56.10",
-    "@types/eslint-config-prettier": "~6.11.3",
     "@types/eslint__js": "~8.42.3",
+    "@types/eslint-config-prettier": "~6.11.3",
     "@types/node": "^20.14.12",
     "@types/strip-comments": "^2.0.4",
     "@vitest/coverage-v8": "^2.0.4",

--- a/src/cli/commands/defaultCommandRunner.ts
+++ b/src/cli/commands/defaultCommandRunner.ts
@@ -1,0 +1,95 @@
+import path from 'node:path';
+import pc from 'picocolors';
+import { PackResult, pack } from '../../core/packager.js';
+import {
+  RepopackConfigCli,
+  RepopackConfigFile,
+  RepopackConfigMerged,
+  RepopackOutputStyle,
+} from '../../config/configTypes.js';
+import { loadFileConfig, mergeConfigs } from '../../config/configLoader.js';
+import { logger } from '../../shared/logger.js';
+import { CliOptions } from '../cliRunner.js';
+import { getVersion } from '../../core/file/packageJsonParser.js';
+import Spinner from './../cliSpinner.js';
+import { printSummary, printTopFiles, printCompletion, printSecurityCheck } from './../cliPrinter.js';
+
+export const runDefaultCommand = async (directory: string, cwd: string, options: CliOptions): Promise<void> => {
+  const version = await getVersion();
+
+  console.log(pc.dim(`\n📦 Repopack v${version}\n`));
+
+  logger.setVerbose(options.verbose || false);
+  logger.trace('Loaded CLI options:', options);
+
+  // Load the config file
+  const fileConfig: RepopackConfigFile = await loadFileConfig(cwd, options.config ?? null);
+  logger.trace('Loaded file config:', fileConfig);
+
+  // Parse the CLI options
+  const cliConfig: RepopackConfigCli = {};
+  if (options.output) {
+    cliConfig.output = { filePath: options.output };
+  }
+  if (options.include) {
+    cliConfig.include = options.include.split(',');
+  }
+  if (options.ignore) {
+    cliConfig.ignore = { customPatterns: options.ignore.split(',') };
+  }
+  if (options.topFilesLen !== undefined) {
+    cliConfig.output = { ...cliConfig.output, topFilesLength: options.topFilesLen };
+  }
+  if (options.outputShowLineNumbers !== undefined) {
+    cliConfig.output = { ...cliConfig.output, showLineNumbers: options.outputShowLineNumbers };
+  }
+  if (options.style) {
+    cliConfig.output = { ...cliConfig.output, style: options.style.toLowerCase() as RepopackOutputStyle };
+  }
+  logger.trace('CLI config:', cliConfig);
+
+  // Merge default, file, and CLI configs
+  const config: RepopackConfigMerged = mergeConfigs(fileConfig, cliConfig);
+
+  logger.trace('Merged config:', config);
+
+  // Ensure the output file is always in the current working directory
+  config.output.filePath = path.resolve(cwd, path.basename(config.output.filePath));
+
+  const targetPath = path.resolve(directory);
+
+  const spinner = new Spinner('Packing files...');
+  spinner.start();
+
+  let packResult: PackResult;
+
+  try {
+    packResult = await pack(targetPath, config);
+  } catch (error) {
+    spinner.fail('Error during packing');
+    throw error;
+  }
+
+  spinner.succeed('Packing completed successfully!');
+  console.log('');
+
+  if (config.output.topFilesLength > 0) {
+    printTopFiles(packResult.fileCharCounts, packResult.fileTokenCounts, config.output.topFilesLength);
+    console.log('');
+  }
+
+  printSecurityCheck(cwd, packResult.suspiciousFilesResults);
+  console.log('');
+
+  printSummary(
+    cwd,
+    packResult.totalFiles,
+    packResult.totalCharacters,
+    packResult.totalTokens,
+    config.output.filePath,
+    packResult.suspiciousFilesResults,
+  );
+  console.log('');
+
+  printCompletion();
+};

--- a/src/cli/commands/initCommandRunner.ts
+++ b/src/cli/commands/initCommandRunner.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { intro, outro, text, select, cancel, group } from '@clack/prompts';
+import pc from 'picocolors';
+import { logger } from '../../shared/logger.js';
+import { RepopackConfigFile, RepopackOutputStyle } from '../../config/configTypes.js';
+import { defaultConfig } from '../../config/defaultConfig.js';
+
+export const runInitCommand = async (rootDir: string): Promise<void> => {
+  const configPath = path.join(rootDir, 'repopack.config.json');
+
+  try {
+    // Check if the config file already exists
+    await fs.access(configPath);
+    console.log(pc.yellow('A repopack.config.json file already exists in this directory.'));
+    console.log(pc.yellow('If you want to create a new one, please delete or rename the existing file first.'));
+    return;
+  } catch {
+    // File doesn't exist, so we can proceed
+  }
+
+  intro(pc.bold(pc.cyan('Welcome to Repopack!')));
+
+  try {
+    const options = await group(
+      {
+        outputFilePath: () =>
+          text({
+            message: 'Output file path:',
+            initialValue: defaultConfig.output.filePath,
+            validate: (value) => (value.length === 0 ? 'Output file path is required' : undefined),
+          }),
+
+        outputStyle: () =>
+          select({
+            message: 'Output style:',
+            options: [
+              { value: 'plain', label: 'Plain', hint: 'Simple text format' },
+              { value: 'xml', label: 'XML', hint: 'Structured XML format' },
+            ],
+            initialValue: defaultConfig.output.style,
+          }),
+      },
+      {
+        onCancel: () => {
+          cancel('Configuration cancelled.');
+          process.exit(0);
+        },
+      },
+    );
+
+    const config: RepopackConfigFile = {
+      ...defaultConfig,
+      output: {
+        ...defaultConfig.output,
+        filePath: options.outputFilePath as string,
+        style: options.outputStyle as RepopackOutputStyle,
+      },
+    };
+
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+
+    outro(
+      pc.cyan('Configuration complete! repopack.config.json has been created.\n') +
+        'You can now run ' +
+        pc.bold('repopack') +
+        ' to pack your repository.\n\n' +
+        pc.yellow('Tip: ') +
+        'You can always edit repopack.config.json manually for more advanced configurations.',
+    );
+  } catch (error) {
+    logger.error('Failed to create repopack.config.json:', error);
+  }
+};

--- a/src/cli/commands/versionCommandRunner.ts
+++ b/src/cli/commands/versionCommandRunner.ts
@@ -1,0 +1,6 @@
+import { getVersion } from '../../core/file/packageJsonParser.js';
+
+export const runVersionCommand = async (): Promise<void> => {
+  const version = await getVersion();
+  console.log(version);
+};


### PR DESCRIPTION
This PR introduces a new `--init` command to Repopack, allowing users to interactively create a basic `repopack.config.json` file. The key changes include:

<img width="629" alt="image" src="https://github.com/user-attachments/assets/592aff3c-8c4b-4d47-a73a-0f3db38669bc">


The `--init` command now allows users to easily set up their initial Repopack configuration by prompting for:
- Output file path
- Output style (plain or XML)

This addition simplifies the process of getting started with Repopack, especially for new users.