### PR TITLE
Refactor Output Generation and Security Check Processes

### DIFF
--- a/src/core/output/outputGenerator.ts
+++ b/src/core/output/outputGenerator.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs/promises';
-import path from 'node:path';
 import { RepopackConfigMerged } from '../../config/configTypes.js';
 import { SanitizedFile } from '../file/fileSanitizer.js';
 import { generateTreeString } from '../file/fileTreeGenerator.js';
@@ -8,12 +6,10 @@ import { generatePlainStyle } from './plainStyleGenerator.js';
 import { OutputGeneratorContext } from './outputGeneratorTypes.js';
 
 export const generateOutput = async (
-  rootDir: string,
   config: RepopackConfigMerged,
   sanitizedFiles: SanitizedFile[],
   allFilePaths: string[],
-  fsModule = fs,
-): Promise<void> => {
+): Promise<string> => {
   const outputGeneratorContext = buildOutputGeneratorContext(config, allFilePaths, sanitizedFiles);
 
   let output: string;
@@ -25,8 +21,7 @@ export const generateOutput = async (
       output = generatePlainStyle(outputGeneratorContext);
   }
 
-  const outputPath = path.resolve(rootDir, config.output.filePath);
-  await fsModule.writeFile(outputPath, output);
+  return output;
 };
 
 export const buildOutputGeneratorContext = (

--- a/tests/core/output/outputGenerator.test.ts
+++ b/tests/core/output/outputGenerator.test.ts
@@ -1,16 +1,8 @@
-import * as fs from 'node:fs/promises';
-import path from 'node:path';
-import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { expect, test, describe } from 'vitest';
 import { generateOutput } from '../../../src/core/output/outputGenerator.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
-vi.mock('fs/promises');
-
 describe('outputGenerator', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
   test('generateOutput should write correct content to file', async () => {
     const mockConfig = createMockConfig({
       output: {
@@ -27,16 +19,12 @@ describe('outputGenerator', () => {
       { path: 'dir/file2.txt', content: 'content2' },
     ];
 
-    await generateOutput('root', mockConfig, mockSanitizedFiles, []);
+    const output = await generateOutput(mockConfig, mockSanitizedFiles, []);
 
-    expect(fs.writeFile).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(path.resolve('root', 'output.txt'));
-
-    const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
-    expect(writtenContent).toContain('Repopack Output File');
-    expect(writtenContent).toContain('File: file1.txt');
-    expect(writtenContent).toContain('content1');
-    expect(writtenContent).toContain('File: dir/file2.txt');
-    expect(writtenContent).toContain('content2');
+    expect(output).toContain('Repopack Output File');
+    expect(output).toContain('File: file1.txt');
+    expect(output).toContain('content1');
+    expect(output).toContain('File: dir/file2.txt');
+    expect(output).toContain('content2');
   });
 });

--- a/tests/core/security/secretLintRunner.test.ts
+++ b/tests/core/security/secretLintRunner.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from 'vitest';
 import type { SecretLintCoreConfig } from '@secretlint/types';
-import { runSecretLint, createSecretLintConfig } from '../../../src/core/security/secretLintRunner.js';
+import { runSecretLint, createSecretLintConfig } from '../../../src/core/security/securityCheckRunner.js';
 
 describe('secretLintRunner', () => {
   const config: SecretLintCoreConfig = createSecretLintConfig();


### PR DESCRIPTION
## Key Changes:

1. Modified `generateOutput` to return a string instead of writing to a file directly.
4. Extracted `runSecurityCheck` function from `pack` for better organization.
