### PR TITLE
Add support for global configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,19 @@ Example configuration:
 }
 ```
 
+### Global Configuration
+To create a global configuration file:
+  
+```bash
+repopack --init --global
+```
+
+The global configuration file will be created in:
+- Windows: `%LOCALAPPDATA%\Repopack\repopack.config.json`
+- macOS/Linux: `$XDG_CONFIG_HOME/repopack/repopack.config.json` or `~/.config/repopack/repopack.config.json`
+
+Note: Local configuration (if present) takes precedence over global configuration.
+
 ### Include and Ignore
 #### Include Patterns
 Repopack now supports specifying files to include using glob patterns. This allows for more flexible and powerful file selection:

--- a/src/cli/cliRunner.ts
+++ b/src/cli/cliRunner.ts
@@ -18,6 +18,7 @@ export interface CliOptions extends OptionValues {
   outputShowLineNumbers?: boolean;
   style?: RepopackOutputStyle;
   init?: boolean;
+  global?: boolean;
 }
 
 export async function run() {
@@ -38,6 +39,7 @@ export async function run() {
       .option('--style <type>', 'specify the output style (plain or xml)')
       .option('--verbose', 'enable verbose logging for detailed output')
       .option('--init', 'initialize a new repopack.config.json file')
+      .option('--global', 'use global configuration (only applicable with --init)')
       .action((directory = '.', options: CliOptions) => executeAction(directory, process.cwd(), options));
 
     await program.parseAsync(process.argv);
@@ -53,7 +55,7 @@ const executeAction = async (directory: string, cwd: string, options: CliOptions
   }
 
   if (options.init) {
-    await runInitAction(cwd);
+    await runInitAction(cwd, options.global || false);
     return;
   }
 

--- a/src/config/globalDirectory.ts
+++ b/src/config/globalDirectory.ts
@@ -1,0 +1,15 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const getGlobalDirectory = () => {
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    return path.join(localAppData, 'Repopack');
+  }
+
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'repopack');
+  }
+
+  return path.join(os.homedir(), '.config', 'repopack');
+};

--- a/tests/cli/actions/initActionRunner.test.ts
+++ b/tests/cli/actions/initActionRunner.test.ts
@@ -4,9 +4,12 @@ import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 import * as prompts from '@clack/prompts';
 import { runInitAction } from '../../../src/cli/actions/initActionRunner.js';
 import { logger } from '../../../src/shared/logger.js';
+import { getGlobalDirectory } from '../../../src/config/globalDirectory.js';
 
 vi.mock('node:fs/promises');
 vi.mock('@clack/prompts');
+vi.mock('../../../src/shared/folderUtils');
+vi.mock('../../../src/config/globalDirectory.js');
 
 describe('initActionRunner', () => {
   beforeEach(() => {
@@ -17,14 +20,14 @@ describe('initActionRunner', () => {
     vi.resetAllMocks();
   });
 
-  it('should create a new config file when one does not exist', async () => {
+  it('should create a new local config file when one does not exist', async () => {
     vi.mocked(fs.access).mockRejectedValue(new Error('File does not exist'));
     vi.mocked(prompts.group).mockResolvedValue({
       outputFilePath: 'custom-output.txt',
       outputStyle: 'xml',
     });
 
-    await runInitAction('/test/dir');
+    await runInitAction('/test/dir', false);
 
     const configPath = path.resolve('/test/dir/repopack.config.json');
 
@@ -32,14 +35,48 @@ describe('initActionRunner', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(configPath, expect.stringContaining('"style": "xml"'));
   });
 
-  it('should not create a new config file when one already exists', async () => {
+  it('should create a new global config file when one does not exist', async () => {
+    vi.mocked(fs.access).mockRejectedValue(new Error('File does not exist'));
+    vi.mocked(prompts.group).mockResolvedValue({
+      outputFilePath: 'global-output.txt',
+      outputStyle: 'plain',
+    });
+    vi.mocked(getGlobalDirectory).mockImplementation(() => '/global/repopack');
+
+    await runInitAction('/test/dir', true);
+
+    const configPath = path.resolve('/global/repopack/repopack.config.json');
+
+    expect(fs.mkdir).toHaveBeenCalledWith(path.dirname(configPath), { recursive: true });
+    expect(fs.writeFile).toHaveBeenCalledWith(configPath, expect.stringContaining('"filePath": "global-output.txt"'));
+    expect(fs.writeFile).toHaveBeenCalledWith(configPath, expect.stringContaining('"style": "plain"'));
+  });
+
+  it('should prompt to overwrite when config file already exists', async () => {
     vi.mocked(fs.access).mockResolvedValue(undefined);
+    vi.mocked(prompts.confirm).mockResolvedValue(true);
+    vi.mocked(prompts.group).mockResolvedValue({
+      outputFilePath: 'new-output.txt',
+      outputStyle: 'xml',
+    });
 
-    const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(vi.fn());
-    await runInitAction('/test/dir');
+    await runInitAction('/test/dir', false);
 
+    expect(prompts.confirm).toHaveBeenCalled();
+    expect(fs.writeFile).toHaveBeenCalled();
+  });
+
+  it('should not overwrite when user chooses not to', async () => {
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+    vi.mocked(prompts.confirm).mockResolvedValue(false);
+
+    const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(vi.fn());
+
+    await runInitAction('/test/dir', false);
+
+    expect(prompts.confirm).toHaveBeenCalled();
     expect(fs.writeFile).not.toHaveBeenCalled();
-    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('already exists'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('will not be modified'));
   });
 
   it('should handle user cancellation', async () => {
@@ -50,21 +87,9 @@ describe('initActionRunner', () => {
 
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(vi.fn());
 
-    await runInitAction('/test/dir');
+    await runInitAction('/test/dir', false);
 
     expect(fs.writeFile).not.toHaveBeenCalled();
-
     expect(loggerSpy).toHaveBeenCalledWith('Failed to create repopack.config.json:', new Error('User cancelled'));
-  });
-
-  it('should handle errors when writing the config file', async () => {
-    vi.mocked(fs.access).mockRejectedValue(new Error('File does not exist'));
-    vi.mocked(prompts.group).mockResolvedValue({
-      outputFilePath: 'custom-output.txt',
-      outputStyle: 'plain',
-    });
-    vi.mocked(fs.writeFile).mockRejectedValue(new Error('Write error'));
-
-    await runInitAction('/test/dir');
   });
 });

--- a/tests/config/globalDirectory.ts
+++ b/tests/config/globalDirectory.ts
@@ -1,0 +1,49 @@
+import os from 'node:os';
+import path from 'node:path';
+import { expect, describe, test, vi, beforeEach } from 'vitest';
+import { getGlobalDirectory } from '../../src/config/globalDirectory.js';
+import { isLinux, isMac, isWindows } from '../testing/testUtils.js';
+
+vi.mock('node:os');
+
+describe('globalDirectory', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = {};
+  });
+
+  test.runIf(isWindows)('should return correct path for Windows', () => {
+    vi.mocked(os.platform).mockReturnValue('win32');
+    vi.mocked(os.homedir).mockReturnValue('C:\\Users\\TestUser');
+    process.env.LOCALAPPDATA = 'C:\\Users\\TestUser\\AppData\\Local';
+
+    const result = getGlobalDirectory();
+    expect(result).toBe(path.join('C:\\Users\\TestUser\\AppData\\Local', 'Repopack'));
+  });
+
+  test.runIf(isWindows)('should use homedir if LOCALAPPDATA is not set on Windows', () => {
+    vi.mocked(os.platform).mockReturnValue('win32');
+    vi.mocked(os.homedir).mockReturnValue('C:\\Users\\TestUser');
+    delete process.env.LOCALAPPDATA;
+
+    const result = getGlobalDirectory();
+    expect(result).toBe(path.join('C:\\Users\\TestUser', 'AppData', 'Local', 'Repopack'));
+  });
+
+  test.runIf(isLinux)('should use XDG_CONFIG_HOME on Unix systems if set', () => {
+    vi.mocked(os.platform).mockReturnValue('linux');
+    process.env.XDG_CONFIG_HOME = '/custom/config';
+
+    const result = getGlobalDirectory();
+    expect(result).toBe(path.join('/custom/config', 'repopack'));
+  });
+
+  test.runIf(isMac)('should use ~/.config on Unix systems if XDG_CONFIG_HOME is not set', () => {
+    vi.mocked(os.platform).mockReturnValue('darwin');
+    vi.mocked(os.homedir).mockReturnValue('/Users/TestUser');
+    delete process.env.XDG_CONFIG_HOME;
+
+    const result = getGlobalDirectory();
+    expect(result).toBe(path.join('/Users/TestUser', '.config', 'repopack'));
+  });
+});

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -11,3 +11,5 @@ export const createMockConfig = (config: Partial<RepopackConfigMerged> = {}): Re
 };
 
 export const isWindows = os.platform() === 'win32';
+export const isMac = os.platform() === 'darwin';
+export const isLinux = os.platform() === 'linux';


### PR DESCRIPTION
related: #51

### Changes
- Add support global config
- Add `repopack --init --global` command to support creating global configuration files

The global configuration file will be created in:
- Windows: `%LOCALAPPDATA%\Repopack\repopack.config.json`
- macOS/Linux: `$XDG_CONFIG_HOME/repopack/repopack.config.json` or `~/.config/repopack/repopack.config.json`

Note: Local configuration (if present) takes precedence over global configuration.

### Motivation
We've added support for global configuration files to allow users to easily maintain common settings across multiple projects. This enhances the Repopack user experience and enables more flexible configuration management.
