### PR TITLE
Fix concurrency issues in environments with unknown CPU count

### DIFF
--- a/src/core/file/fileCollector.ts
+++ b/src/core/file/fileCollector.ts
@@ -1,11 +1,11 @@
 import * as fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import { isBinary } from 'istextorbinary';
 import jschardet from 'jschardet';
 import iconv from 'iconv-lite';
 import pMap from 'p-map';
 import { logger } from '../../shared/logger.js';
+import { getProcessConcurrency } from '../../shared/processConcurrency.js';
 import { RawFile } from './fileTypes.js';
 
 export const collectFiles = async (filePaths: string[], rootDir: string): Promise<RawFile[]> => {
@@ -20,7 +20,7 @@ export const collectFiles = async (filePaths: string[], rootDir: string): Promis
       return null;
     },
     {
-      concurrency: os.cpus().length,
+      concurrency: getProcessConcurrency(),
     },
   );
 

--- a/src/core/file/fileProcessor.ts
+++ b/src/core/file/fileProcessor.ts
@@ -1,6 +1,6 @@
-import os from 'node:os';
 import pMap from 'p-map';
 import { RepopackConfigMerged } from '../../config/configTypes.js';
+import { getProcessConcurrency } from '../../shared/processConcurrency.js';
 import { getFileManipulator } from './fileManipulater.js';
 import { ProcessedFile, RawFile } from './fileTypes.js';
 
@@ -12,7 +12,7 @@ export const processFiles = async (rawFiles: RawFile[], config: RepopackConfigMe
       content: await processContent(rawFile.content, rawFile.path, config),
     }),
     {
-      concurrency: os.cpus().length,
+      concurrency: getProcessConcurrency(),
     },
   );
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -1,8 +1,8 @@
-import os from 'node:os';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import pMap from 'p-map';
 import { RepopackConfigMerged } from '../config/configTypes.js';
+import { getProcessConcurrency } from '../shared/processConcurrency.js';
 import { generateOutput as defaultGenerateOutput } from './output/outputGenerator.js';
 import { SuspiciousFileResult, runSecurityCheck as defaultRunSecurityCheck } from './security/securityCheckRunner.js';
 import { searchFiles as defaultSearchFiles } from './file/fileSearcher.js';
@@ -73,7 +73,7 @@ export const pack = async (
       return { path: file.path, charCount, tokenCount };
     },
     {
-      concurrency: os.cpus().length,
+      concurrency: getProcessConcurrency(),
     },
   );
 

--- a/src/core/security/securityCheckRunner.ts
+++ b/src/core/security/securityCheckRunner.ts
@@ -1,10 +1,10 @@
-import os from 'node:os';
 import type { SecretLintCoreConfig, SecretLintCoreResult } from '@secretlint/types';
 import { lintSource } from '@secretlint/core';
 import { creator } from '@secretlint/secretlint-rule-preset-recommend';
 import pMap from 'p-map';
 import { logger } from '../../shared/logger.js';
 import { RawFile } from '../file/fileTypes.js';
+import { getProcessConcurrency } from '../../shared/processConcurrency.js';
 
 export interface SuspiciousFileResult {
   filePath: string;
@@ -27,7 +27,7 @@ export const runSecurityCheck = async (rawFiles: RawFile[]): Promise<SuspiciousF
       return null;
     },
     {
-      concurrency: os.cpus().length,
+      concurrency: getProcessConcurrency(),
     },
   );
 

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -1,0 +1,13 @@
+import os from 'node:os';
+
+export const getProcessConcurrency = () => {
+  const cpuCount = os.cpus().length;
+
+  // Fallback for environments where os.cpus().length returns 0
+  // see: https://github.com/yamadashy/repopack/issues/56
+  if (cpuCount === 0) {
+    return 1;
+  }
+
+  return cpuCount;
+};


### PR DESCRIPTION
This PR addresses the issue where Repopack fails in environments where `os.cpus().length` returns 0.

Changes:
- Add `getProcessConcurrency()` function that returns 1 if CPU count is 0

Note: This issue is known to affect some Termux on Android setups. For more context, see: https://github.com/termux/termux-packages/issues/1798

Fixes #56