### PR TITLE
Fix Python comment removal to preserve f-strings

### DIFF
--- a/src/core/file/fileManipulator.ts
+++ b/src/core/file/fileManipulator.ts
@@ -37,15 +37,8 @@ class StripCommentsManipulator extends BaseManipulator {
 
 class PythonManipulator extends BaseManipulator {
   removeComments(content: string): string {
-    // First, use strip-comments to remove standard comments
-    let result = strip(content, { language: 'python', preserveNewlines: true });
-
-    // Then, remove triple-quote comments
-    result = result.replace(/'''[\s\S]*?'''/g, '');
-    result = result.replace(/"""[\s\S]*?"""/g, '');
-
-    // Then, remove inline comments
-    result = result.replace(/(?<!\\)#.*$/gm, '');
+    // Remove single-line comments
+    const result = content.replace(/(?<!\\)#.*$/gm, '');
 
     return rtrimLines(result);
   }

--- a/src/core/file/fileProcessor.ts
+++ b/src/core/file/fileProcessor.ts
@@ -1,7 +1,7 @@
 import pMap from 'p-map';
 import { RepopackConfigMerged } from '../../config/configTypes.js';
 import { getProcessConcurrency } from '../../shared/processConcurrency.js';
-import { getFileManipulator } from './fileManipulater.js';
+import { getFileManipulator } from './fileManipulator.js';
 import { ProcessedFile, RawFile } from './fileTypes.js';
 
 export const processFiles = async (rawFiles: RawFile[], config: RepopackConfigMerged): Promise<ProcessedFile[]> => {

--- a/tests/core/file/fileManipulator.test.ts
+++ b/tests/core/file/fileManipulator.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'vitest';
-import { getFileManipulator } from '../../../src/core/file/fileManipulater.js';
+import { getFileManipulator } from '../../../src/core/file/fileManipulator.js';
 
 describe('fileManipulator', () => {
   const testCases = [
@@ -156,21 +156,23 @@ describe('fileManipulator', () => {
         # Single line comment
         def test():
           '''
-          Multi-line comment
+          docstring
           '''
           return True
         """
-        Another multi-line comment
+        Another docstring
         """
       `,
       expected: `
 
         def test():
-
+          '''
+          docstring
+          '''
           return True
-
-
-
+        """
+        Another docstring
+        """
 `,
     },
     {

--- a/tests/core/file/fileProcessor.test.ts
+++ b/tests/core/file/fileProcessor.test.ts
@@ -1,10 +1,10 @@
 import { expect, describe, it, vi } from 'vitest';
 import { processFiles, processContent } from '../../../src/core/file/fileProcessor.js';
-import { getFileManipulator } from '../../../src/core/file/fileManipulater.js';
+import { getFileManipulator } from '../../../src/core/file/fileManipulator.js';
 import { RawFile } from '../../../src/core/file/fileTypes.js';
 import { createMockConfig } from '../../testing/testUtils.js';
 
-vi.mock('../../../src/core/file/fileManipulater');
+vi.mock('../../../src/core/file/fileManipulator');
 
 describe('fileProcessor', () => {
   describe('processFiles', () => {


### PR DESCRIPTION
This PR simplifies our approach to removing comments from Python files.

#55

### Changes:
- Only remove single-line comments starting with '#'
  - Preserve all other content, including string literals and f-strings
  - Do not attempt to remove docstrings or multi-line comments

This change resolves the issue with f-strings being incorrectly removed while simplifying our overall approach to comment removal.
