### PR TITLE
Add remote repository processing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ To exclude specific files or directories:
 repopack --ignore "**/*.log,tmp/"
 ```
 
+To pack a remote repository:
+```bash
+repopack --remote https://github.com/yamadashy/repopack
+
+# You can also use GitHub shorthand:
+repopack --remote yamadashy/repopack
+```
+
 To initialize a new configuration file (`repopack.config.json`):
 
 ```bash
@@ -212,6 +220,7 @@ This means that the XML output from Repopack is not just a different format, but
 - `--style <style>`: Specify the output style (`plain` or `xml`)
 - `--top-files-len <number>`: Number of top files to display in the summary
 - `--output-show-line-numbers`: Show line numbers in the output
+- `--remote <url>`: Process a remote Git repository
 - `--verbose`: Enable verbose logging
 
 Examples:
@@ -220,6 +229,7 @@ repopack -o custom-output.txt
 repopack -i "*.log,tmp" -v
 repopack -c ./custom-config.json
 repopack --style xml
+repopack --remote https://github.com/user/repo.git
 npx repopack src
 ```
 
@@ -237,6 +247,22 @@ yarn global upgrade repopack
 
 Using `npx repopack` is generally more convenient as it always uses the latest version.
 
+
+### Remote Repository Processing
+
+Repopack supports processing remote Git repositories without the need for manual cloning. This feature allows you to quickly analyze any public Git repository with a single command.
+
+To process a remote repository, use the `--remote` option followed by the repository URL:
+
+```bash
+repopack --remote https://github.com/user/repo.git
+```
+
+You can also use GitHub's shorthand format:
+
+```bash
+repopack --remote user/repo
+```
 
 
 ## ⚙️ Configuration

--- a/src/cli/actions/remoteActionRunner.ts
+++ b/src/cli/actions/remoteActionRunner.ts
@@ -1,0 +1,102 @@
+import os from 'node:os';
+import path from 'node:path';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
+import pc from 'picocolors';
+import { CliOptions } from '../cliRunner.js';
+import { logger } from '../../shared/logger.js';
+import { RepopackError } from '../../shared/errorHandler.js';
+import Spinner from '../cliSpinner.js';
+import { runDefaultAction } from './defaultActionRunner.js';
+
+const execAsync = promisify(exec);
+
+export const runRemoteAction = async (repoUrl: string, options: CliOptions): Promise<void> => {
+  const gitInstalled = await checkGitInstallation();
+  if (!gitInstalled) {
+    throw new RepopackError('Git is not installed or not in the system PATH.');
+  }
+
+  const formattedUrl = formatGitUrl(repoUrl);
+  const tempDir = await createTempDirectory();
+  const spinner = new Spinner('Cloning repository...');
+
+  try {
+    spinner.start();
+    await cloneRepository(formattedUrl, tempDir);
+    spinner.succeed('Repository cloned successfully!');
+    const result = await runDefaultAction(tempDir, tempDir, options);
+    await copyOutputToCurrentDirectory(tempDir, process.cwd(), result.config.output.filePath);
+  } finally {
+    // Clean up the temporary directory
+    await cleanupTempDirectory(tempDir);
+  }
+};
+
+export const formatGitUrl = (url: string): string => {
+  // If the URL is in the format owner/repo, convert it to a GitHub URL
+  if (/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/.test(url)) {
+    logger.trace(`Formatting GitHub shorthand: ${url}`);
+    return `https://github.com/${url}.git`;
+  }
+
+  // Add .git to HTTPS URLs if missing
+  if (url.startsWith('https://') && !url.endsWith('.git')) {
+    logger.trace(`Adding .git to HTTPS URL: ${url}`);
+    return `${url}.git`;
+  }
+
+  return url;
+};
+
+const createTempDirectory = async (): Promise<string> => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repopack-'));
+  logger.trace(`Created temporary directory. (path: ${pc.dim(tempDir)})`);
+  return tempDir;
+};
+
+const cloneRepository = async (url: string, directory: string): Promise<void> => {
+  logger.log(`Clone repository: ${url} to temporary directory. ${pc.dim('path: ' + directory)}`);
+  logger.log('');
+
+  try {
+    await execAsync(`git clone --depth 1 ${url} ${directory}`);
+  } catch (error) {
+    throw new RepopackError(`Failed to clone repository: ${(error as Error).message}`);
+  }
+};
+
+const cleanupTempDirectory = async (directory: string): Promise<void> => {
+  logger.trace(`Cleaning up temporary directory: ${directory}`);
+  await fs.rm(directory, { recursive: true, force: true });
+};
+
+const checkGitInstallation = async (): Promise<boolean> => {
+  try {
+    const result = await execAsync('git --version');
+    if (result.stderr) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logger.debug('Git is not installed:', (error as Error).message);
+    return false;
+  }
+};
+
+const copyOutputToCurrentDirectory = async (
+  sourceDir: string,
+  targetDir: string,
+  outputFileName: string,
+): Promise<void> => {
+  const sourcePath = path.join(sourceDir, outputFileName);
+  const targetPath = path.join(targetDir, outputFileName);
+
+  try {
+    logger.trace(`Copying output file from: ${sourcePath} to: ${targetPath}`);
+    await fs.copyFile(sourcePath, targetPath);
+  } catch (error) {
+    throw new RepopackError(`Failed to copy output file: ${(error as Error).message}`);
+  }
+};

--- a/src/cli/cliPrinter.ts
+++ b/src/cli/cliPrinter.ts
@@ -4,15 +4,12 @@ import { logger } from '../shared/logger.js';
 import { SuspiciousFileResult } from '../core/security/securityCheckRunner.js';
 
 export const printSummary = (
-  rootDir: string,
   totalFiles: number,
   totalCharacters: number,
   totalTokens: number,
   outputPath: string,
   suspiciousFilesResults: SuspiciousFileResult[],
 ) => {
-  const relativeOutputPath = path.relative(rootDir, outputPath);
-
   let securityCheckMessage = '';
   if (suspiciousFilesResults.length > 0) {
     securityCheckMessage = pc.yellow(`${suspiciousFilesResults.length} suspicious file(s) detected and excluded`);
@@ -25,7 +22,7 @@ export const printSummary = (
   logger.log(`${pc.white('  Total Files:')} ${pc.white(totalFiles.toString())}`);
   logger.log(`${pc.white('  Total Chars:')} ${pc.white(totalCharacters.toString())}`);
   logger.log(`${pc.white(' Total Tokens:')} ${pc.white(totalTokens.toString())}`);
-  logger.log(`${pc.white('       Output:')} ${pc.white(relativeOutputPath)}`);
+  logger.log(`${pc.white('       Output:')} ${pc.white(outputPath)}`);
   logger.log(`${pc.white('     Security:')} ${pc.white(securityCheckMessage)}`);
 };
 

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -76,7 +76,12 @@ const loadAndValidateConfig = async (filePath: string): Promise<RepopackConfigFi
   }
 };
 
-export const mergeConfigs = (fileConfig: RepopackConfigFile, cliConfig: RepopackConfigCli): RepopackConfigMerged => ({
+export const mergeConfigs = (
+  cwd: string,
+  fileConfig: RepopackConfigFile,
+  cliConfig: RepopackConfigCli,
+): RepopackConfigMerged => ({
+  cwd,
   output: {
     ...defaultConfig.output,
     ...fileConfig.output,

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -40,4 +40,8 @@ export type RepopackConfigFile = RepopackConfigBase;
 
 export type RepopackConfigCli = RepopackConfigBase;
 
-export type RepopackConfigMerged = RepopackConfigDefault & RepopackConfigFile & RepopackConfigCli;
+export type RepopackConfigMerged = RepopackConfigDefault &
+  RepopackConfigFile &
+  RepopackConfigCli & {
+    cwd: string;
+  };

--- a/src/core/file/fileSearcher.ts
+++ b/src/core/file/fileSearcher.ts
@@ -62,20 +62,19 @@ export const getIgnorePatterns = async (rootDir: string, config: RepopackConfigM
 
   // Add default ignore patterns
   if (config.ignore.useDefaultPatterns) {
+    logger.trace('Adding default ignore patterns');
     ignorePatterns = [...ignorePatterns, ...defaultIgnoreList];
   }
 
   // Add repopack output file
   if (config.output.filePath) {
-    let relativeOutputPath = config.output.filePath.replace(rootDir, '');
-    if (relativeOutputPath.startsWith('/')) {
-      relativeOutputPath = relativeOutputPath.slice(1);
-    }
-    ignorePatterns.push(relativeOutputPath);
+    logger.trace('Adding output file to ignore patterns:', config.output.filePath);
+    ignorePatterns.push(config.output.filePath);
   }
 
   // Add custom ignore patterns
   if (config.ignore.customPatterns) {
+    logger.trace('Adding default custom ignore patterns: ', config.ignore.customPatterns);
     ignorePatterns = [...ignorePatterns, ...config.ignore.customPatterns];
   }
 

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import pMap from 'p-map';
 import { RepopackConfigMerged } from '../config/configTypes.js';
 import { getProcessConcurrency } from '../shared/processConcurrency.js';
+import { logger } from '../shared/logger.js';
 import { generateOutput as defaultGenerateOutput } from './output/outputGenerator.js';
 import { SuspiciousFileResult, runSecurityCheck as defaultRunSecurityCheck } from './security/securityCheckRunner.js';
 import { searchFiles as defaultSearchFiles } from './file/fileSearcher.js';
@@ -57,8 +58,9 @@ export const pack = async (
   // Generate output
   const output = await deps.generateOutput(config, processedFiles, safeFilePaths);
 
-  // Write output to file
-  const outputPath = path.resolve(rootDir, config.output.filePath);
+  // Write output to file. path is relative to the cwd
+  const outputPath = path.resolve(config.cwd, config.output.filePath);
+  logger.trace(`Writing output to: ${outputPath}`);
   await fs.writeFile(outputPath, output);
 
   // Setup token counter

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -9,5 +9,6 @@ export const getProcessConcurrency = () => {
     return 1;
   }
 
-  return cpuCount;
+  // Use all available CPUs except one
+  return Math.max(1, cpuCount - 1);
 };

--- a/tests/cli/actions/defaultActionRunner.test.ts
+++ b/tests/cli/actions/defaultActionRunner.test.ts
@@ -1,9 +1,9 @@
+import process from 'node:process';
 import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 import { runDefaultAction } from '../../../src/cli/actions/defaultActionRunner.js';
 import * as packager from '../../../src/core/packager.js';
 import * as configLoader from '../../../src/config/configLoader.js';
 import * as packageJsonParser from '../../../src/core/file/packageJsonParser.js';
-import * as logger from '../../../src/shared/logger.js';
 import { CliOptions } from '../../../src/cli/cliRunner.js';
 
 vi.mock('../../../src/core/packager');
@@ -17,6 +17,7 @@ describe('defaultActionRunner', () => {
     vi.mocked(packageJsonParser.getVersion).mockResolvedValue('1.0.0');
     vi.mocked(configLoader.loadFileConfig).mockResolvedValue({});
     vi.mocked(configLoader.mergeConfigs).mockReturnValue({
+      cwd: process.cwd(),
       output: {
         filePath: 'output.txt',
         style: 'plain',
@@ -54,8 +55,6 @@ describe('defaultActionRunner', () => {
 
     await runDefaultAction('.', process.cwd(), options);
 
-    expect(packageJsonParser.getVersion).toHaveBeenCalled();
-    expect(logger.logger.setVerbose).toHaveBeenCalledWith(true);
     expect(configLoader.loadFileConfig).toHaveBeenCalled();
     expect(configLoader.mergeConfigs).toHaveBeenCalled();
     expect(packager.pack).toHaveBeenCalled();
@@ -69,6 +68,7 @@ describe('defaultActionRunner', () => {
     await runDefaultAction('.', process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+      process.cwd(),
       expect.anything(),
       expect.objectContaining({
         include: ['*.js', '*.ts'],
@@ -84,6 +84,7 @@ describe('defaultActionRunner', () => {
     await runDefaultAction('.', process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+      process.cwd(),
       expect.anything(),
       expect.objectContaining({
         ignore: {
@@ -101,6 +102,7 @@ describe('defaultActionRunner', () => {
     await runDefaultAction('.', process.cwd(), options);
 
     expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+      process.cwd(),
       expect.anything(),
       expect.objectContaining({
         output: expect.objectContaining({

--- a/tests/cli/actions/remoteActionRunner.test.ts
+++ b/tests/cli/actions/remoteActionRunner.test.ts
@@ -1,0 +1,43 @@
+import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
+import { formatGitUrl } from '../../../src/cli/actions/remoteActionRunner.js';
+
+vi.mock('node:fs/promises');
+vi.mock('node:child_process');
+vi.mock('../../../src/cli/actions/defaultActionRunner.js');
+vi.mock('../../../src/shared/logger.js');
+
+describe('remoteActionRunner', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('formatGitUrl', () => {
+    it('should format GitHub shorthand correctly', () => {
+      expect(formatGitUrl('user/repo')).toBe('https://github.com/user/repo.git');
+      expect(formatGitUrl('user-name/repo-name')).toBe('https://github.com/user-name/repo-name.git');
+      expect(formatGitUrl('user_name/repo_name')).toBe('https://github.com/user_name/repo_name.git');
+    });
+
+    it('should add .git to HTTPS URLs if missing', () => {
+      expect(formatGitUrl('https://github.com/user/repo')).toBe('https://github.com/user/repo.git');
+    });
+
+    it('should not modify URLs that are already correctly formatted', () => {
+      expect(formatGitUrl('https://github.com/user/repo.git')).toBe('https://github.com/user/repo.git');
+      expect(formatGitUrl('git@github.com:user/repo.git')).toBe('git@github.com:user/repo.git');
+    });
+
+    it('should not modify SSH URLs', () => {
+      expect(formatGitUrl('git@github.com:user/repo.git')).toBe('git@github.com:user/repo.git');
+    });
+
+    it('should not modify URLs from other Git hosting services', () => {
+      expect(formatGitUrl('https://gitlab.com/user/repo.git')).toBe('https://gitlab.com/user/repo.git');
+      expect(formatGitUrl('https://bitbucket.org/user/repo.git')).toBe('https://bitbucket.org/user/repo.git');
+    });
+  });
+});

--- a/tests/config/configLoader.test.ts
+++ b/tests/config/configLoader.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import process from 'node:process';
 import { Stats } from 'node:fs';
 import path from 'node:path';
 import { expect, test, describe, vi, beforeEach } from 'vitest';
@@ -83,7 +84,7 @@ describe('configLoader', () => {
         ignore: { customPatterns: ['cli-ignore'] },
       };
 
-      const result = mergeConfigs(fileConfig, cliConfig);
+      const result = mergeConfigs(process.cwd(), fileConfig, cliConfig);
 
       expect(result.output.filePath).toBe('cli-output.txt');
       expect(result.ignore.useDefaultPatterns).toBe(true);

--- a/tests/integration-tests/packager.test.ts
+++ b/tests/integration-tests/packager.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import process from 'node:process';
 import { expect, test, describe, beforeEach, afterEach } from 'vitest';
 import { pack } from '../../src/core/packager.js';
 import { RepopackConfigFile, RepopackConfigMerged, RepopackOutputStyle } from '../../src/config/configTypes.js';
@@ -41,7 +42,7 @@ describe.runIf(!isWindows)('packager integration', () => {
       const actualOutputPath = path.join(tempDir, output);
 
       const fileConfig: RepopackConfigFile = await loadFileConfig(inputDir, null);
-      const mergedConfig: RepopackConfigMerged = mergeConfigs(fileConfig, {
+      const mergedConfig: RepopackConfigMerged = mergeConfigs(process.cwd(), fileConfig, {
         output: {
           filePath: actualOutputPath,
           style: (config.output?.style || 'plain') as RepopackOutputStyle,

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -1,4 +1,5 @@
 import os from 'node:os';
+import process from 'node:process';
 import { RepopackConfigMerged } from '../../src/config/configTypes.js';
 import { defaultConfig } from '../../src/config/defaultConfig.js';
 
@@ -14,6 +15,7 @@ type DeepPartial<T> = {
 
 export const createMockConfig = (config: DeepPartial<RepopackConfigMerged> = {}): RepopackConfigMerged => {
   return {
+    cwd: process.cwd(),
     output: {
       ...defaultConfig.output,
       ...config.output,


### PR DESCRIPTION
This PR introduces a new feature that allows Repopack to process remote Git repositories without requiring local cloning by the user. This enhancement significantly expands the tool's capabilities and improves user experience.

## Key Changes
- Added new `--remote` option to process remote Git repositories

## Usage Examples
Process a GitHub repository:
```bash
repopack --remote https://github.com/user/repo.git
```

Use GitHub shorthand:
```bash
repopack --remote user/repo
```


## Implementation Details
- Created new file: `src/cli/actions/remoteActionRunner.ts`
- Updated `src/cli/cliRunner.ts` to include the new `--remote` option
- Utilized `cliSpinner` for rich visual feedback during processing
- Implemented error handling for various scenarios (Git not installed, clone failure, etc.)
- Ensured proper cleanup of temporary directories
information is needed.