### PR TITLE
Enhance Repopack initialization process for better user experience

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "files": {
+    "include": [
+      "./src/**",
+      "./tests/**",
+      "package.json",
+      "biome.json",
+      ".secretlintrc.json",
+      "tsconfig.json",
+      "tsconfig.build.json",
+      "vite.config.ts",
+      "repopack.config.json"
+    ]
+  },
   "organizeImports": {
     "enabled": true
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "npm run clean && tsc -p tsconfig.build.json --sourceMap --declaration",
-    "lint": "biome lint --write ./src ./tests && biome format --write ./src ./tests && biome check --write ./src ./tests && tsc --noEmit && secretlint **/*",
+    "lint": "biome lint --write && biome format --write && biome check --write && tsc --noEmit && secretlint **/*",
     "test": "vitest",
     "test-coverage": "vitest run --coverage",
     "cli-run": "npm run build && node --trace-warnings bin/repopack",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "types": ["node", "picocolors"]
   },
   "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["tests/integration-tests/fixtures"],
+  "exclude": ["tests/integration-tests/fixtures"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -9,5 +9,5 @@ export default defineConfig({
       include: ['src/**/*'],
       reporter: ['text', 'json', 'html'],
     },
-  }
-})
+  },
+});


### PR DESCRIPTION
Key changes:
1. Separated the creation processes for repopack.config.json and .repopackignore files, allowing users more granular control over their setup.

These improvements will make it easier for new users to get started with Repopack and provide a smoother configuration experience for all users.
