### PR TITLE
Add option to control security check

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Here's an explanation of the configuration options:
 |`ignore.useGitignore`| Whether to use patterns from the project's `.gitignore` file |`true`|
 |`ignore.useDefaultPatterns`| Whether to use default ignore patterns |`true`|
 |`ignore.customPatterns`| Additional patterns to ignore (using glob patterns) |`[]`|
+|`security.enableSecurityCheck`| Whether to perform security checks on files |`true`|
 
 Example configuration:
 
@@ -320,6 +321,9 @@ Example configuration:
     "useGitignore": true,
     "useDefaultPatterns": true,
     "customPatterns": ["additional-folder", "**/*.log"]
+  },
+  "security": {
+    "enableSecurityCheck": true
   }
 }
 ```
@@ -429,6 +433,16 @@ Example output:
 2. tests/utils/secretLintUtils.test.ts
 
 Please review these files for potential sensitive information.
+```
+
+By default, the security check is enabled. You can disable it by setting `security.enableSecurityCheck` to `false` in your configuration file:
+
+```json
+{
+  "security": {
+    "enableSecurityCheck": false
+  }
+}
 ```
 
 

--- a/repopack.config.json
+++ b/repopack.config.json
@@ -14,5 +14,8 @@
     "useGitignore": true,
     "useDefaultPatterns": true,
     "customPatterns": []
+  },
+  "security": {
+    "enableSecurityCheck": true
   }
 }

--- a/src/cli/actions/defaultActionRunner.ts
+++ b/src/cli/actions/defaultActionRunner.ts
@@ -79,7 +79,7 @@ export const runDefaultAction = async (
     logger.log('');
   }
 
-  printSecurityCheck(cwd, packResult.suspiciousFilesResults);
+  printSecurityCheck(cwd, packResult.suspiciousFilesResults, config);
   logger.log('');
 
   printSummary(
@@ -88,6 +88,7 @@ export const runDefaultAction = async (
     packResult.totalTokens,
     config.output.filePath,
     packResult.suspiciousFilesResults,
+    config,
   );
   logger.log('');
 

--- a/src/cli/cliPrinter.ts
+++ b/src/cli/cliPrinter.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import pc from 'picocolors';
+import type { RepopackConfigMerged } from '../config/configTypes.js';
 import type { SuspiciousFileResult } from '../core/security/securityCheckRunner.js';
 import { logger } from '../shared/logger.js';
 
@@ -9,12 +10,17 @@ export const printSummary = (
   totalTokens: number,
   outputPath: string,
   suspiciousFilesResults: SuspiciousFileResult[],
+  config: RepopackConfigMerged,
 ) => {
   let securityCheckMessage = '';
-  if (suspiciousFilesResults.length > 0) {
-    securityCheckMessage = pc.yellow(`${suspiciousFilesResults.length} suspicious file(s) detected and excluded`);
+  if (config.security.enableSecurityCheck) {
+    if (suspiciousFilesResults.length > 0) {
+      securityCheckMessage = pc.yellow(`${suspiciousFilesResults.length} suspicious file(s) detected and excluded`);
+    } else {
+      securityCheckMessage = pc.white('✔ No suspicious files detected');
+    }
   } else {
-    securityCheckMessage = pc.white('✔ No suspicious files detected');
+    securityCheckMessage = pc.dim('Security check disabled');
   }
 
   logger.log(pc.white('📊 Pack Summary:'));
@@ -26,7 +32,15 @@ export const printSummary = (
   logger.log(`${pc.white('     Security:')} ${pc.white(securityCheckMessage)}`);
 };
 
-export const printSecurityCheck = (rootDir: string, suspiciousFilesResults: SuspiciousFileResult[]) => {
+export const printSecurityCheck = (
+  rootDir: string,
+  suspiciousFilesResults: SuspiciousFileResult[],
+  config: RepopackConfigMerged,
+) => {
+  if (!config.security.enableSecurityCheck) {
+    return;
+  }
+
   logger.log(pc.white('🔎 Security Check:'));
   logger.log(pc.dim('──────────────────'));
 

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -99,4 +99,9 @@ export const mergeConfigs = (
     ],
   },
   include: [...(defaultConfig.include || []), ...(fileConfig.include || []), ...(cliConfig.include || [])],
+  security: {
+    ...defaultConfig.security,
+    ...fileConfig.security,
+    ...cliConfig.security,
+  },
 });

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -17,6 +17,9 @@ interface RepopackConfigBase {
     useDefaultPatterns?: boolean;
     customPatterns?: string[];
   };
+  security?: {
+    enableSecurityCheck?: boolean;
+  };
 }
 
 export type RepopackConfigDefault = RepopackConfigBase & {
@@ -35,6 +38,9 @@ export type RepopackConfigDefault = RepopackConfigBase & {
     useGitignore: boolean;
     useDefaultPatterns: boolean;
     customPatterns?: string[];
+  };
+  security: {
+    enableSecurityCheck: boolean;
   };
 };
 

--- a/src/config/configValidator.ts
+++ b/src/config/configValidator.ts
@@ -13,7 +13,7 @@ export function validateConfig(config: unknown): asserts config is RepopackConfi
     throw new RepopackConfigValidationError('Configuration must be an object');
   }
 
-  const { output, ignore } = config as Partial<RepopackConfigFile>;
+  const { output, ignore, security } = config as Partial<RepopackConfigFile>;
 
   // Validate output
   if (output !== undefined) {
@@ -38,7 +38,7 @@ export function validateConfig(config: unknown): asserts config is RepopackConfi
     }
   }
 
-  // Validate ignore (existing code remains unchanged)
+  // Validate ignore
   if (ignore !== undefined) {
     if (typeof ignore !== 'object' || ignore == null) {
       throw new RepopackConfigValidationError('ignore must be an object');
@@ -55,6 +55,18 @@ export function validateConfig(config: unknown): asserts config is RepopackConfi
       if (!customPatterns.every((pattern) => typeof pattern === 'string')) {
         throw new RepopackConfigValidationError('All items in ignore.customPatterns must be strings');
       }
+    }
+  }
+
+  // Validate security
+  if (security !== undefined) {
+    if (typeof security !== 'object' || security == null) {
+      throw new RepopackConfigValidationError('security must be an object');
+    }
+
+    const { enableSecurityCheck } = security;
+    if (enableSecurityCheck !== undefined && typeof enableSecurityCheck !== 'boolean') {
+      throw new RepopackConfigValidationError('security.enableSecurityCheck must be a boolean');
     }
   }
 }

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -15,4 +15,7 @@ export const defaultConfig: RepopackConfigDefault = {
     useDefaultPatterns: true,
     customPatterns: [],
   },
+  security: {
+    enableSecurityCheck: true,
+  },
 };

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -53,12 +53,18 @@ export const pack = async (
   progressCallback('Collecting files...');
   const rawFiles = await deps.collectFiles(filePaths, rootDir);
 
-  // Perform security check and filter out suspicious files
-  progressCallback('Running security check...');
-  const suspiciousFilesResults = await deps.runSecurityCheck(rawFiles, progressCallback);
-  const safeRawFiles = rawFiles.filter(
-    (rawFile) => !suspiciousFilesResults.some((result) => result.filePath === rawFile.path),
-  );
+  let safeRawFiles = rawFiles;
+  let suspiciousFilesResults: SuspiciousFileResult[] = [];
+
+  if (config.security.enableSecurityCheck) {
+    // Perform security check and filter out suspicious files
+    progressCallback('Running security check...');
+    suspiciousFilesResults = await deps.runSecurityCheck(rawFiles, progressCallback);
+    safeRawFiles = rawFiles.filter(
+      (rawFile) => !suspiciousFilesResults.some((result) => result.filePath === rawFile.path),
+    );
+  }
+
   const safeFilePaths = safeRawFiles.map((file) => file.path);
   logger.trace('Safe files count:', safeRawFiles.length);
 

--- a/tests/cli/actions/defaultActionRunner.test.ts
+++ b/tests/cli/actions/defaultActionRunner.test.ts
@@ -32,6 +32,9 @@ describe('defaultActionRunner', () => {
         customPatterns: [],
       },
       include: [],
+      security: {
+        enableSecurityCheck: true,
+      },
     });
     vi.mocked(packager.pack).mockResolvedValue({
       totalFiles: 10,

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -26,6 +26,10 @@ export const createMockConfig = (config: DeepPartial<RepopackConfigMerged> = {})
       customPatterns: [...(defaultConfig.ignore.customPatterns || []), ...(config.ignore?.customPatterns || [])],
     },
     include: [...(defaultConfig.include || []), ...(config.include || [])],
+    security: {
+      ...defaultConfig.security,
+      ...config.security,
+    },
   };
 };
 


### PR DESCRIPTION
This PR introduces an option to control the security check, allowing users to enable or disable the security check as needed.

related: #74

Key changes:
- Add new config option `security.enableSecurityCheck` (default is `true`)
- Update packager to conditionally run security check based on this setting

## Implementation

- The `security.enableSecurityCheck` option is added to the configuration schema
- When set to `false`, the packager skips the security check process
- CLI output is updated to indicate whether the security check was performed or skipped
- Default behavior (security check enabled) remains unchanged for existing users
