### PR TITLE
feat(style): Add Markdown output style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage/
 # Repopack output
 repopack-output.txt
 repopack-output.xml
+repopack-output.md
 
 # ESLint cache
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -223,6 +223,45 @@ https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-
 
 This means that the XML output from Repopack is not just a different format, but potentially a more effective way to feed your codebase into AI systems for analysis, code review, or other tasks.
 
+#### Markdown Format
+
+To generate output in Markdown format, use the `--style markdown` option:
+```bash
+repopack --style markdown
+```
+
+The Markdown format structures the content in a hierarchical manner:
+
+````markdown
+This file is a merged representation of the entire codebase, combining all repository files into a single document.
+
+# File Summary
+(Metadata and usage AI instructions)
+
+# Repository Structure
+```
+src/
+  cli/
+    cliOutput.ts
+    index.ts
+```
+(...remaining directories)
+
+# Repository Files
+
+## File: src/index.js
+```
+// File contents here
+```
+
+(...remaining files)
+
+# Instruction
+(Custom instructions from `output.instructionFilePath`)
+````
+
+This format provides a clean, readable structure that is both human-friendly and easily parseable by AI systems.
+
 ### Command Line Options
 
 - `-v, --version`: Show tool version
@@ -230,7 +269,7 @@ This means that the XML output from Repopack is not just a different format, but
 - `--include <patterns>`: List of include patterns (comma-separated)
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `-c, --config <path>`: Path to a custom config file
-- `--style <style>`: Specify the output style (`plain` or `xml`)
+- `--style <style>`: Specify the output style (`plain`, `xml`, `markdown`)
 - `--top-files-len <number>`: Number of top files to display in the summary
 - `--output-show-line-numbers`: Show line numbers in the output
 - `--remote <url>`: Process a remote Git repository
@@ -290,7 +329,7 @@ Here's an explanation of the configuration options:
 | Option | Description | Default |
 |--------|-------------|---------|
 |`output.filePath`| The name of the output file | `"repopack-output.txt"` |
-|`output.style`| The style of the output (`plain`, `xml`) |`"plain"`|
+|`output.style`| The style of the output (`plain`, `xml`, `markdown`) |`"plain"`|
 |`output.headerText`| Custom text to include in the file header |`null`|
 |`output.instructionFilePath`| Path to a file containing detailed custom instructions |`null`|
 |`output.removeComments`| Whether to remove comments from supported file types | `false` |

--- a/src/cli/cliRunner.ts
+++ b/src/cli/cliRunner.ts
@@ -39,7 +39,7 @@ export async function run() {
       .option('-c, --config <path>', 'path to a custom config file')
       .option('--top-files-len <number>', 'specify the number of top files to display', Number.parseInt)
       .option('--output-show-line-numbers', 'add line numbers to each line in the output')
-      .option('--style <type>', 'specify the output style (plain or xml)')
+      .option('--style <type>', 'specify the output style (plain, xml, markdown)')
       .option('--verbose', 'enable verbose logging for detailed output')
       .option('--init', 'initialize a new repopack.config.json file')
       .option('--global', 'use global configuration (only applicable with --init)')

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -1,4 +1,4 @@
-export type RepopackOutputStyle = 'plain' | 'xml';
+export type RepopackOutputStyle = 'plain' | 'xml' | 'markdown';
 
 interface RepopackConfigBase {
   output?: {

--- a/src/core/output/markdownStyleGenerator.ts
+++ b/src/core/output/markdownStyleGenerator.ts
@@ -9,8 +9,8 @@ import {
   generateSummaryUsageGuidelines,
 } from './outputStyleDecorator.js';
 
-export const generatePlainStyle = (outputGeneratorContext: OutputGeneratorContext) => {
-  const template = Handlebars.compile(plainTemplate);
+export const generateMarkdownStyle = (outputGeneratorContext: OutputGeneratorContext) => {
+  const template = Handlebars.compile(markdownTemplate);
 
   const renderContext = {
     generationHeader: generateHeader(outputGeneratorContext.generationDate),
@@ -31,70 +31,51 @@ export const generatePlainStyle = (outputGeneratorContext: OutputGeneratorContex
   return `${template(renderContext).trim()}\n`;
 };
 
-const PLAIN_SEPARATOR = '='.repeat(16);
-const PLAIN_LONG_SEPARATOR = '='.repeat(64);
-
-const plainTemplate = `
+const markdownTemplate = /* md */ `
 {{{generationHeader}}}
 
-${PLAIN_LONG_SEPARATOR}
-File Summary
-${PLAIN_LONG_SEPARATOR}
+# File Summary
 
-Purpose:
---------
+## Purpose
 {{{summaryPurpose}}}
 
-File Format:
-------------
+## File Format
 {{{summaryFileFormat}}}
 4. Multiple file entries, each consisting of:
-  a. A separator line (================)
-  b. The file path (File: path/to/file)
-  c. Another separator line
-  d. The full contents of the file
-  e. A blank line
+  a. A header with the file path (## File: path/to/file)
+  b. The full contents of the file in a code block
 
-Usage Guidelines:
------------------
+## Usage Guidelines
 {{{summaryUsageGuidelines}}}
 
-Notes:
-------
+## Notes
 {{{summaryNotes}}}
 
-Additional Info:
-----------------
+## Additional Info
 {{#if headerText}}
-User Provided Header:
------------------------
+### User Provided Header
 {{{headerText}}}
 {{/if}}
 
 {{{summaryAdditionalInfo}}}
 
-${PLAIN_LONG_SEPARATOR}
-Repository Structure
-${PLAIN_LONG_SEPARATOR}
+# Repository Structure
+\`\`\`
 {{{treeString}}}
+\`\`\`
 
-${PLAIN_LONG_SEPARATOR}
-Repository Files
-${PLAIN_LONG_SEPARATOR}
+# Repository Files
 
 {{#each processedFiles}}
-${PLAIN_SEPARATOR}
-File: {{{this.path}}}
-${PLAIN_SEPARATOR}
+## File: {{{this.path}}}
+\`\`\`
 {{{this.content}}}
+\`\`\`
 
 {{/each}}
 
 {{#if instruction}}
-${PLAIN_LONG_SEPARATOR}
-Instruction
-${PLAIN_LONG_SEPARATOR}
+# Instruction
 {{{instruction}}}
 {{/if}}
-
 `;

--- a/src/core/output/outputGenerator.ts
+++ b/src/core/output/outputGenerator.ts
@@ -4,6 +4,7 @@ import type { RepopackConfigMerged } from '../../config/configTypes.js';
 import { RepopackError } from '../../shared/errorHandler.js';
 import { generateTreeString } from '../file/fileTreeGenerator.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
+import { generateMarkdownStyle } from './markdownStyleGenerator.js';
 import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
 import { generatePlainStyle } from './plainStyleGenerator.js';
 import { generateXmlStyle } from './xmlStyleGenerator.js';
@@ -20,6 +21,9 @@ export const generateOutput = async (
   switch (config.output.style) {
     case 'xml':
       output = generateXmlStyle(outputGeneratorContext);
+      break;
+    case 'markdown':
+      output = generateMarkdownStyle(outputGeneratorContext);
       break;
     default:
       output = generatePlainStyle(outputGeneratorContext);

--- a/src/core/output/xmlStyleGenerator.ts
+++ b/src/core/output/xmlStyleGenerator.ts
@@ -31,7 +31,7 @@ export const generateXmlStyle = (outputGeneratorContext: OutputGeneratorContext)
   return `${template(renderContext).trim()}\n`;
 };
 
-const xmlTemplate = `
+const xmlTemplate = /* xml */ `
 {{{generationHeader}}}
 
 <file_summary>

--- a/tests/core/output/markdownStyleGenerator.test.ts
+++ b/tests/core/output/markdownStyleGenerator.test.ts
@@ -1,0 +1,34 @@
+import process from 'node:process';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { generateMarkdownStyle } from '../../../src/core/output/markdownStyleGenerator.js';
+import { buildOutputGeneratorContext } from '../../../src/core/output/outputGenerator.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+vi.mock('fs/promises');
+
+describe('outputGenerator', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('generateMarkdownOutput should include user-provided header text', async () => {
+    const mockConfig = createMockConfig({
+      output: {
+        filePath: 'output.md',
+        style: 'markdown',
+        headerText: 'Custom header text',
+        topFilesLength: 2,
+        showLineNumbers: false,
+        removeComments: false,
+        removeEmptyLines: false,
+      },
+    });
+
+    const context = await buildOutputGeneratorContext(process.cwd(), mockConfig, [], []);
+    const output = await generateMarkdownStyle(context);
+
+    expect(output).toContain('# File Summary');
+    expect(output).toContain('# Repository Structure');
+    expect(output).toContain('# Repository Files');
+  });
+});


### PR DESCRIPTION
This PR introduces a new Markdown output style for Repopack, providing users with an additional option for formatting their repository content.

related: #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Markdown output format for the Repopack tool, enhancing the versatility of output options.
	- Updated command line options to support the new Markdown style.

- **Documentation**
	- Updated the README to include instructions for generating Markdown output and detailed the new command line options.

- **Tests**
	- Added a test suite for validating the functionality of the new Markdown output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->