### PR TITLE
Refactor `searchInPairs` and Enhance `rtrimLines` Functions

### DIFF
--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -134,7 +134,45 @@ class PythonManipulator extends BaseManipulator {
   }
 }
 
-const manipulators: Record<string, FileManipulator> = {};
+const manipulators: Record<string, FileManipulator> = {
+  '.c': new StripCommentsManipulator('c'),
+  '.cs': new StripCommentsManipulator('csharp'),
+  '.css': new StripCommentsManipulator('css'),
+  '.dart': new StripCommentsManipulator('c'),
+  '.go': new StripCommentsManipulator('c'),
+  '.html': new StripCommentsManipulator('html'),
+  '.java': new StripCommentsManipulator('java'),
+  '.js': new StripCommentsManipulator('javascript'),
+  '.jsx': new StripCommentsManipulator('javascript'),
+  '.kt': new StripCommentsManipulator('c'),
+  '.less': new StripCommentsManipulator('less'),
+  '.php': new StripCommentsManipulator('php'),
+  '.rb': new StripCommentsManipulator('ruby'),
+  '.rs': new StripCommentsManipulator('c'),
+  '.sass': new StripCommentsManipulator('sass'),
+  '.scss': new StripCommentsManipulator('sass'),
+  '.sh': new StripCommentsManipulator('perl'),
+  '.sql': new StripCommentsManipulator('sql'),
+  '.swift': new StripCommentsManipulator('swift'),
+  '.ts': new StripCommentsManipulator('javascript'),
+  '.tsx': new StripCommentsManipulator('javascript'),
+  '.xml': new StripCommentsManipulator('xml'),
+  '.yaml': new StripCommentsManipulator('perl'),
+  '.yml': new StripCommentsManipulator('perl'),
+
+  '.py': new PythonManipulator(),
+
+  '.vue': new CompositeManipulator(
+    new StripCommentsManipulator('html'),
+    new StripCommentsManipulator('css'),
+    new StripCommentsManipulator('javascript'),
+  ),
+  '.svelte': new CompositeManipulator(
+    new StripCommentsManipulator('html'),
+    new StripCommentsManipulator('css'),
+    new StripCommentsManipulator('javascript'),
+  ),
+};
 
 const getOrCreateManipulator = (ext: string): FileManipulator => {
   if (!manipulators[ext]) {

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -12,7 +12,6 @@ const rtrimLines = (content: string): string =>
     .map((line) => line.trimEnd())
     .join('\n');
 
-
 class BaseManipulator implements FileManipulator {
   removeComments(content: string): string {
     return content;
@@ -145,7 +144,6 @@ class PythonManipulator extends BaseManipulator {
     }
     return result;
   }
-
 
   removeComments(content: string): string {
     let result = this.removeDocStrings(content);

--- a/src/core/file/fileManipulate.ts
+++ b/src/core/file/fileManipulate.ts
@@ -103,7 +103,7 @@ class PythonManipulator extends BaseManipulator {
       const openingQuote = content.slice(prevQuote + 1).search(/(?<!\\)(?:"|'|'''|""")/g) + prevQuote + 1;
       if (openingQuote === prevQuote) break;
 
-      let closingQuote;
+      let closingQuote = -1;
       if (content.startsWith('"""', openingQuote) || content.startsWith("'''", openingQuote)) {
         const quoteType = content.slice(openingQuote, openingQuote + 3);
         closingQuote = content.indexOf(quoteType, openingQuote + 3);


### PR DESCRIPTION
This pull request includes the following changes:

1. **Refactored `searchInPairs`**:
   - Simplified the binary search logic for determining if a `hashIndex` falls within string literal pairs. This enhances code readability and maintainability.

2. **Enhanced `rtrimLines` Function**:
   - Modified the implementation to utilize `String.prototype.trimEnd()` for trimming trailing whitespace from each line, improving performance and efficiency.

These changes aim to streamline the code while maintaining the existing functionality and ensuring that all tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified methods for removing docstrings and hash comments in Python files, improving efficiency.
	- Introduced a new function to manage the instantiation of file manipulators based on file extensions.

- **Refactor**
	- Enhanced clarity and maintainability of code by streamlining comment removal logic.
	- Updated the line trimming method to improve readability and efficiency.
	- Retained the `CompositeManipulator` class while restructuring manipulator instantiation and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->