### PR TITLE
fix: Allow markdown as valid option in configuration

### DIFF
--- a/src/config/configValidate.ts
+++ b/src/config/configValidate.ts
@@ -32,8 +32,8 @@ export function validateConfig(config: unknown): asserts config is RepopackConfi
       if (typeof style !== 'string') {
         throw new RepopackConfigValidationError('output.style must be a string');
       }
-      if (style !== 'plain' && style !== 'xml') {
-        throw new RepopackConfigValidationError('output.style must be either "plain" or "xml"');
+      if (style !== 'plain' && style !== 'xml' && style !== 'markdown') {
+        throw new RepopackConfigValidationError('output.style must be either "plain", "xml" or "markdown"');
       }
     }
   }

--- a/tests/config/configValidate.test.ts
+++ b/tests/config/configValidate.test.ts
@@ -46,6 +46,6 @@ describe('configValidate', () => {
   test('should throw for invalid output.style value', () => {
     const invalidConfig = { output: { style: 'invalid' } };
     expect(() => validateConfig(invalidConfig)).toThrow(RepopackConfigValidationError);
-    expect(() => validateConfig(invalidConfig)).toThrow('output.style must be either "plain" or "xml"');
+    expect(() => validateConfig(invalidConfig)).toThrow('output.style must be either "plain", "xml" or "markdown"');
   });
 });


### PR DESCRIPTION
Running `repopack` with `output.style` set to `markdown` generates the following error:

```
Error: Invalid configuration in /path/to/repo/repopack.config.json: output.style must be either "plain" or "xml"
```