### PR TITLE
Refactor Styles & OutputGenerate functions to streamline generation process

### DIFF
--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -1,13 +1,41 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import Handlebars from 'handlebars';
 import type { RepopackConfigMerged } from '../../config/configTypes.js';
 import { RepopackError } from '../../shared/errorHandle.js';
 import { generateTreeString } from '../file/fileTreeGenerate.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
-import { generateMarkdownStyle } from './outputStyles/markdownStyle.js';
-import { generatePlainStyle } from './outputStyles/plainStyle.js';
-import { generateXmlStyle } from './outputStyles/xmlStyle.js';
+import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
+import { getXmlTemplate } from './outputStyles/xmlStyle.js';
+import { getPlainTemplate } from './outputStyles/plainStyle.js';
+import {
+  generateHeader,
+  generateSummaryAdditionalInfo,
+  generateSummaryFileFormat,
+  generateSummaryNotes,
+  generateSummaryPurpose,
+  generateSummaryUsageGuidelines,
+} from './outputStyleDecorate.js';
+
+
+const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => {
+  return {
+    generationHeader: generateHeader(outputGeneratorContext.generationDate),
+    summaryPurpose: generateSummaryPurpose(),
+    summaryFileFormat: generateSummaryFileFormat(),
+    summaryUsageGuidelines: generateSummaryUsageGuidelines(
+      outputGeneratorContext.config,
+      outputGeneratorContext.instruction,
+    ),
+    summaryNotes: generateSummaryNotes(outputGeneratorContext.config),
+    summaryAdditionalInfo: generateSummaryAdditionalInfo(),
+    headerText: outputGeneratorContext.config.output.headerText,
+    instruction: outputGeneratorContext.instruction,
+    treeString: outputGeneratorContext.treeString,
+    processedFiles: outputGeneratorContext.processedFiles,
+  };
+}
 
 export const generateOutput = async (
   rootDir: string,
@@ -16,20 +44,22 @@ export const generateOutput = async (
   allFilePaths: string[],
 ): Promise<string> => {
   const outputGeneratorContext = await buildOutputGeneratorContext(rootDir, config, allFilePaths, processedFiles);
+  const renderContext = createRenderContext(outputGeneratorContext);
 
-  let output: string;
+  let template: string;
   switch (config.output.style) {
     case 'xml':
-      output = generateXmlStyle(outputGeneratorContext);
+      template = getXmlTemplate();
       break;
     case 'markdown':
-      output = generateMarkdownStyle(outputGeneratorContext);
+      template = getMarkdownTemplate();
       break;
     default:
-      output = generatePlainStyle(outputGeneratorContext);
+      template = getPlainTemplate();
   }
 
-  return output;
+  const compiledTemplate = Handlebars.compile(template);
+  return `${compiledTemplate(renderContext).trim()}\n`;
 };
 
 export const buildOutputGeneratorContext = async (

--- a/src/core/output/outputGenerate.ts
+++ b/src/core/output/outputGenerate.ts
@@ -6,9 +6,6 @@ import { RepopackError } from '../../shared/errorHandle.js';
 import { generateTreeString } from '../file/fileTreeGenerate.js';
 import type { ProcessedFile } from '../file/fileTypes.js';
 import type { OutputGeneratorContext } from './outputGeneratorTypes.js';
-import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
-import { getXmlTemplate } from './outputStyles/xmlStyle.js';
-import { getPlainTemplate } from './outputStyles/plainStyle.js';
 import {
   generateHeader,
   generateSummaryAdditionalInfo,
@@ -17,7 +14,9 @@ import {
   generateSummaryPurpose,
   generateSummaryUsageGuidelines,
 } from './outputStyleDecorate.js';
-
+import { getMarkdownTemplate } from './outputStyles/markdownStyle.js';
+import { getPlainTemplate } from './outputStyles/plainStyle.js';
+import { getXmlTemplate } from './outputStyles/xmlStyle.js';
 
 const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => {
   return {
@@ -35,7 +34,7 @@ const createRenderContext = (outputGeneratorContext: OutputGeneratorContext) => 
     treeString: outputGeneratorContext.treeString,
     processedFiles: outputGeneratorContext.processedFiles,
   };
-}
+};
 
 export const generateOutput = async (
   rootDir: string,

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -1,8 +1,7 @@
 import Handlebars from 'handlebars';
 
 export const getMarkdownTemplate = () => {
-
-  return  /* md */ `
+  return /* md */ `
 {{{generationHeader}}}
 
 # File Summary
@@ -50,7 +49,7 @@ export const getMarkdownTemplate = () => {
 {{{instruction}}}
 {{/if}}
 `;
-}
+};
 
 Handlebars.registerHelper('getFileExtension', (filePath) => {
   const extension = filePath.split('.').pop()?.toLowerCase();

--- a/src/core/output/outputStyles/markdownStyle.ts
+++ b/src/core/output/outputStyles/markdownStyle.ts
@@ -1,37 +1,8 @@
 import Handlebars from 'handlebars';
-import type { OutputGeneratorContext } from '../outputGeneratorTypes.js';
-import {
-  generateHeader,
-  generateSummaryAdditionalInfo,
-  generateSummaryFileFormat,
-  generateSummaryNotes,
-  generateSummaryPurpose,
-  generateSummaryUsageGuidelines,
-} from '../outputStyleDecorate.js';
 
-export const generateMarkdownStyle = (outputGeneratorContext: OutputGeneratorContext) => {
-  const template = Handlebars.compile(markdownTemplate);
+export const getMarkdownTemplate = () => {
 
-  const renderContext = {
-    generationHeader: generateHeader(outputGeneratorContext.generationDate),
-    summaryPurpose: generateSummaryPurpose(),
-    summaryFileFormat: generateSummaryFileFormat(),
-    summaryUsageGuidelines: generateSummaryUsageGuidelines(
-      outputGeneratorContext.config,
-      outputGeneratorContext.instruction,
-    ),
-    summaryNotes: generateSummaryNotes(outputGeneratorContext.config),
-    summaryAdditionalInfo: generateSummaryAdditionalInfo(),
-    headerText: outputGeneratorContext.config.output.headerText,
-    instruction: outputGeneratorContext.instruction,
-    treeString: outputGeneratorContext.treeString,
-    processedFiles: outputGeneratorContext.processedFiles,
-  };
-
-  return `${template(renderContext).trim()}\n`;
-};
-
-const markdownTemplate = /* md */ `
+  return  /* md */ `
 {{{generationHeader}}}
 
 # File Summary
@@ -79,6 +50,7 @@ const markdownTemplate = /* md */ `
 {{{instruction}}}
 {{/if}}
 `;
+}
 
 Handlebars.registerHelper('getFileExtension', (filePath) => {
   const extension = filePath.split('.').pop()?.toLowerCase();

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -1,40 +1,9 @@
-import Handlebars from 'handlebars';
-import type { OutputGeneratorContext } from '../outputGeneratorTypes.js';
-import {
-  generateHeader,
-  generateSummaryAdditionalInfo,
-  generateSummaryFileFormat,
-  generateSummaryNotes,
-  generateSummaryPurpose,
-  generateSummaryUsageGuidelines,
-} from '../outputStyleDecorate.js';
-
-export const generatePlainStyle = (outputGeneratorContext: OutputGeneratorContext) => {
-  const template = Handlebars.compile(plainTemplate);
-
-  const renderContext = {
-    generationHeader: generateHeader(outputGeneratorContext.generationDate),
-    summaryPurpose: generateSummaryPurpose(),
-    summaryFileFormat: generateSummaryFileFormat(),
-    summaryUsageGuidelines: generateSummaryUsageGuidelines(
-      outputGeneratorContext.config,
-      outputGeneratorContext.instruction,
-    ),
-    summaryNotes: generateSummaryNotes(outputGeneratorContext.config),
-    summaryAdditionalInfo: generateSummaryAdditionalInfo(),
-    headerText: outputGeneratorContext.config.output.headerText,
-    instruction: outputGeneratorContext.instruction,
-    treeString: outputGeneratorContext.treeString,
-    processedFiles: outputGeneratorContext.processedFiles,
-  };
-
-  return `${template(renderContext).trim()}\n`;
-};
-
 const PLAIN_SEPARATOR = '='.repeat(16);
 const PLAIN_LONG_SEPARATOR = '='.repeat(64);
 
-const plainTemplate = `
+export const getPlainTemplate = () => {
+
+  return `
 {{{generationHeader}}}
 
 ${PLAIN_LONG_SEPARATOR}
@@ -98,3 +67,4 @@ ${PLAIN_LONG_SEPARATOR}
 {{/if}}
 
 `;
+}

--- a/src/core/output/outputStyles/plainStyle.ts
+++ b/src/core/output/outputStyles/plainStyle.ts
@@ -2,7 +2,6 @@ const PLAIN_SEPARATOR = '='.repeat(16);
 const PLAIN_LONG_SEPARATOR = '='.repeat(64);
 
 export const getPlainTemplate = () => {
-
   return `
 {{{generationHeader}}}
 
@@ -67,4 +66,4 @@ ${PLAIN_LONG_SEPARATOR}
 {{/if}}
 
 `;
-}
+};

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -1,37 +1,6 @@
-import Handlebars from 'handlebars';
-import type { OutputGeneratorContext } from '../outputGeneratorTypes.js';
-import {
-  generateHeader,
-  generateSummaryAdditionalInfo,
-  generateSummaryFileFormat,
-  generateSummaryNotes,
-  generateSummaryPurpose,
-  generateSummaryUsageGuidelines,
-} from '../outputStyleDecorate.js';
+export const getXmlTemplate = () => {
 
-export const generateXmlStyle = (outputGeneratorContext: OutputGeneratorContext) => {
-  const template = Handlebars.compile(xmlTemplate);
-
-  const renderContext = {
-    generationHeader: generateHeader(outputGeneratorContext.generationDate),
-    summaryPurpose: generateSummaryPurpose(),
-    summaryFileFormat: generateSummaryFileFormat(),
-    summaryUsageGuidelines: generateSummaryUsageGuidelines(
-      outputGeneratorContext.config,
-      outputGeneratorContext.instruction,
-    ),
-    summaryNotes: generateSummaryNotes(outputGeneratorContext.config),
-    summaryAdditionalInfo: generateSummaryAdditionalInfo(),
-    headerText: outputGeneratorContext.config.output.headerText,
-    instruction: outputGeneratorContext.instruction,
-    treeString: outputGeneratorContext.treeString,
-    processedFiles: outputGeneratorContext.processedFiles,
-  };
-
-  return `${template(renderContext).trim()}\n`;
-};
-
-const xmlTemplate = /* xml */ `
+  return  /* xml */ `
 {{{generationHeader}}}
 
 <file_summary>
@@ -89,3 +58,4 @@ This section contains the contents of the repository's files.
 </instruction>
 {{/if}}
 `;
+}

--- a/src/core/output/outputStyles/xmlStyle.ts
+++ b/src/core/output/outputStyles/xmlStyle.ts
@@ -1,6 +1,5 @@
 export const getXmlTemplate = () => {
-
-  return  /* xml */ `
+  return /* xml */ `
 {{{generationHeader}}}
 
 <file_summary>
@@ -58,4 +57,4 @@ This section contains the contents of the repository's files.
 </instruction>
 {{/if}}
 `;
-}
+};

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { buildOutputGeneratorContext } from '../../../../src/core/output/outputGenerate.js';
-import { generateMarkdownStyle } from '../../../../src/core/output/outputStyles/markdownStyle.js';
+import { generateOutput } from '../../../../src/core/output/outputGenerate.js';
 import { createMockConfig } from '../../../testing/testUtils.js';
 
 vi.mock('fs/promises');
@@ -11,7 +10,7 @@ describe('markdownStyle', () => {
     vi.resetAllMocks();
   });
 
-  test('generateMarkdownOutput should include user-provided header text', async () => {
+  test('generateOutput for md should include user-provided header text', async () => {
     const mockConfig = createMockConfig({
       output: {
         filePath: 'output.md',
@@ -24,8 +23,8 @@ describe('markdownStyle', () => {
       },
     });
 
-    const context = await buildOutputGeneratorContext(process.cwd(), mockConfig, [], []);
-    const output = await generateMarkdownStyle(context);
+    const output = await generateOutput(process.cwd(), mockConfig, [], []);
+
 
     expect(output).toContain('# File Summary');
     expect(output).toContain('# Repository Structure');

--- a/tests/core/output/outputStyles/markdownStyle.test.ts
+++ b/tests/core/output/outputStyles/markdownStyle.test.ts
@@ -25,7 +25,6 @@ describe('markdownStyle', () => {
 
     const output = await generateOutput(process.cwd(), mockConfig, [], []);
 
-
     expect(output).toContain('# File Summary');
     expect(output).toContain('# Repository Structure');
     expect(output).toContain('# Repository Files');

--- a/tests/core/output/outputStyles/plainStyle.test.ts
+++ b/tests/core/output/outputStyles/plainStyle.test.ts
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { buildOutputGeneratorContext } from '../../../../src/core/output/outputGenerate.js';
-import { generatePlainStyle } from '../../../../src/core/output/outputStyles/plainStyle.js';
+import { generateOutput } from '../../../../src/core/output/outputGenerate.js';
 import { createMockConfig } from '../../../testing/testUtils.js';
 
 vi.mock('fs/promises');
@@ -11,7 +10,7 @@ describe('plainStyle', () => {
     vi.resetAllMocks();
   });
 
-  test('generatePlainOutput should include user-provided header text', async () => {
+  test('generateOutput for plain should include user-provided header text', async () => {
     const mockConfig = createMockConfig({
       output: {
         filePath: 'output.txt',
@@ -24,8 +23,7 @@ describe('plainStyle', () => {
       },
     });
 
-    const context = await buildOutputGeneratorContext(process.cwd(), mockConfig, [], []);
-    const output = await generatePlainStyle(context);
+    const output = await generateOutput(process.cwd(), mockConfig, [], []);
 
     expect(output).toContain('File Summary');
     expect(output).toContain('Repository Structure');

--- a/tests/core/output/outputStyles/xmlStyle.test.ts
+++ b/tests/core/output/outputStyles/xmlStyle.test.ts
@@ -1,8 +1,8 @@
 import process from 'node:process';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { buildOutputGeneratorContext } from '../../../../src/core/output/outputGenerate.js';
-import { generateXmlStyle } from '../../../../src/core/output/outputStyles/xmlStyle.js';
 import { createMockConfig } from '../../../testing/testUtils.js';
+import { generateOutput } from '../../../../src/core/output/outputGenerate.js';
+
 
 vi.mock('fs/promises');
 
@@ -11,7 +11,7 @@ describe('xmlStyle', () => {
     vi.resetAllMocks();
   });
 
-  test('generateXmlOutput should include user-provided header text', async () => {
+  test('generateOutput for xml should include user-provided header text', async () => {
     const mockConfig = createMockConfig({
       output: {
         filePath: 'output.txt',
@@ -24,8 +24,7 @@ describe('xmlStyle', () => {
       },
     });
 
-    const context = await buildOutputGeneratorContext(process.cwd(), mockConfig, [], []);
-    const output = await generateXmlStyle(context);
+    const output = await generateOutput(process.cwd(), mockConfig, [], []);
 
     expect(output).toContain('file_summary');
     expect(output).toContain('repository_structure');

--- a/tests/core/output/outputStyles/xmlStyle.test.ts
+++ b/tests/core/output/outputStyles/xmlStyle.test.ts
@@ -1,8 +1,7 @@
 import process from 'node:process';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { createMockConfig } from '../../../testing/testUtils.js';
 import { generateOutput } from '../../../../src/core/output/outputGenerate.js';
-
+import { createMockConfig } from '../../../testing/testUtils.js';
 
 vi.mock('fs/promises');
 


### PR DESCRIPTION
This refactor fixes the duplication of renderContext and the generation process for each style while maintaining functionality. 

## All Changes
1. Modified `outputGenerate.ts`:
   - Added a new `createRenderContext` function
   - Centralized template compilation and rendering in `generateOutput` function

2. `plainStyle.ts`, `xmlStyle.ts`, and `markdownStyle.ts` now return template strings

3. Updated tests to reflect new changes:
   - Modified tests function for all styles
   - Ensured tests cover template structure, placeholder presence, and correct rendering

 All existing tests have been updated, passed and manually tested to ensure output remains consistent with previous versions