### PR TITLE
fix(processConcurrency): improve process concurrency count

### DIFF
--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -1,9 +1,7 @@
 import os from 'node:os';
 
 export const getProcessConcurrency = () => {
-  const cpuCount = typeof os.availableParallelism === 'function'
-    ? os.availableParallelism()
-    : (os.cpus().length || 1);
+  const cpuCount = typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length || 1;
 
   // Use all available CPUs except one
   return Math.max(1, cpuCount - 1);

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -1,13 +1,7 @@
 import os from 'node:os';
 
 export const getProcessConcurrency = () => {
-  const cpuCount = os.cpus().length;
-
-  // Fallback for environments where os.cpus().length returns 0
-  // see: https://github.com/yamadashy/repopack/issues/56
-  if (cpuCount === 0) {
-    return 1;
-  }
+  const cpuCount = os.availableParallelism();
 
   // Use all available CPUs except one
   return Math.max(1, cpuCount - 1);

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 
 export const getProcessConcurrency = () => {
-  const cpuCount = typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length || 1;
+  const cpuCount = typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;
 
   // Use all available CPUs except one
   return Math.max(1, cpuCount - 1);

--- a/src/shared/processConcurrency.ts
+++ b/src/shared/processConcurrency.ts
@@ -1,7 +1,9 @@
 import os from 'node:os';
 
 export const getProcessConcurrency = () => {
-  const cpuCount = os.availableParallelism();
+  const cpuCount = typeof os.availableParallelism === 'function'
+    ? os.availableParallelism()
+    : (os.cpus().length || 1);
 
   // Use all available CPUs except one
   return Math.max(1, cpuCount - 1);


### PR DESCRIPTION
This method returns an estimate of the default amount of parallelism a program should use, compared to `cpus().length` which returns the cpu core count.