### PR TITLE
fix: use async setTimeout for sleep

### DIFF
--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import pMap from 'p-map';
 import pc from 'picocolors';
 import type { RepopackConfigMerged } from '../config/configTypes.js';
 import { logger } from '../shared/logger.js';
 import { getProcessConcurrency } from '../shared/processConcurrency.js';
-import { sleep } from '../shared/sleep.js';
 import type { RepopackProgressCallback } from '../shared/types.js';
 import { collectFiles as defaultCollectFiles } from './file/fileCollect.js';
 import { processFiles as defaultProcessFiles } from './file/fileProcess.js';
@@ -94,7 +94,7 @@ export const pack = async (
       progressCallback(`Calculating metrics... (${index + 1}/${processedFiles.length}) ${pc.dim(file.path)}`);
 
       // Sleep for a short time to prevent blocking the event loop
-      await sleep(1);
+      await setTimeout(1);
 
       return { path: file.path, charCount, tokenCount };
     },

--- a/src/core/security/securityCheck.ts
+++ b/src/core/security/securityCheck.ts
@@ -1,10 +1,7 @@
 import { setTimeout } from 'node:timers/promises';
 import { lintSource } from '@secretlint/core';
 import { creator } from '@secretlint/secretlint-rule-preset-recommend';
-import type {
-  SecretLintCoreConfig,
-  SecretLintCoreResult,
-} from '@secretlint/types';
+import type { SecretLintCoreConfig, SecretLintCoreResult } from '@secretlint/types';
 import pMap from 'p-map';
 import pc from 'picocolors';
 import { logger } from '../../shared/logger.js';
@@ -19,24 +16,16 @@ export interface SuspiciousFileResult {
 
 export const runSecurityCheck = async (
   rawFiles: RawFile[],
-  progressCallback: RepopackProgressCallback = () => {}
+  progressCallback: RepopackProgressCallback = () => {},
 ): Promise<SuspiciousFileResult[]> => {
   const secretLintConfig = createSecretLintConfig();
 
   const results = await pMap(
     rawFiles,
     async (rawFile, index) => {
-      const secretLintResult = await runSecretLint(
-        rawFile.path,
-        rawFile.content,
-        secretLintConfig
-      );
+      const secretLintResult = await runSecretLint(rawFile.path, rawFile.content, secretLintConfig);
 
-      progressCallback(
-        `Running security check... (${index + 1}/${rawFiles.length}) ${pc.dim(
-          rawFile.path
-        )}`
-      );
+      progressCallback(`Running security check... (${index + 1}/${rawFiles.length}) ${pc.dim(rawFile.path)}`);
 
       // Sleep for a short time to prevent blocking the event loop
       await setTimeout(1);
@@ -52,18 +41,16 @@ export const runSecurityCheck = async (
     },
     {
       concurrency: getProcessConcurrency(),
-    }
+    },
   );
 
-  return results.filter(
-    (result): result is SuspiciousFileResult => result != null
-  );
+  return results.filter((result): result is SuspiciousFileResult => result != null);
 };
 
 export const runSecretLint = async (
   filePath: string,
   content: string,
-  config: SecretLintCoreConfig
+  config: SecretLintCoreConfig,
 ): Promise<SecretLintCoreResult> => {
   const result = await lintSource({
     source: {
@@ -79,9 +66,7 @@ export const runSecretLint = async (
 
   if (result.messages.length > 0) {
     logger.trace(`Found ${result.messages.length} issues in ${filePath}`);
-    logger.trace(
-      result.messages.map((message) => `  - ${message.message}`).join('\n')
-    );
+    logger.trace(result.messages.map((message) => `  - ${message.message}`).join('\n'));
   }
 
   return result;

--- a/src/shared/sleep.ts
+++ b/src/shared/sleep.ts
@@ -1,1 +1,0 @@
-export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
```ts
const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
```

This type of hack is not needed since node comes with promise based timers module which can be used as:

```ts
import { setTimeout } from 'node:timers/promises'

await setTimeout(1000)
```